### PR TITLE
adds CMake file and fixes compilation issues for Mac

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -1,0 +1,34 @@
+# SWMM LIBRARY
+cmake_minimum_required (VERSION 2.6)
+
+project (SWMM)
+
+SET(CMAKE_C_FLAGS "-std=c99 -fopenmp")
+SET(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
+SET(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
+SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
+add_definitions(-std=c99)
+
+IF(APPLE)
+  SET(CMAKE_INSTALL_NAME_DIR @executable_path)
+  SET(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
+ENDIF(APPLE)
+
+# includes and source files
+include_directories(../src)
+file(GLOB SWMM_SOURCES ../src/*.c)
+
+# library
+add_library(swmm SHARED ${SWMM_SOURCES})
+target_link_libraries(swmm m pthread)
+
+
+# executable
+add_executable(run-swmm ${SWMM_SOURCES})
+target_compile_definitions(run-swmm PRIVATE CLE=TRUE)
+target_link_libraries(run-swmm m pthread)
+
+
+# install
+install(TARGETS swmm DESTINATION lib)
+install(FILES ../src/swmm5.h DESTINATION include)

--- a/src/controls.c
+++ b/src/controls.c
@@ -49,7 +49,7 @@
 #define _CRT_SECURE_NO_DEPRECATE
 
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <math.h>
 #include "headers.h"
 

--- a/src/dynwave.c
+++ b/src/dynwave.c
@@ -37,7 +37,7 @@
 #define _CRT_SECURE_NO_DEPRECATE
 
 #include "headers.h"
-#include <malloc.h>
+#include <stdlib.h>
 #include <math.h>
 #include <omp.h>                                                               //(5.1.008)
 

--- a/src/exfil.c
+++ b/src/exfil.c
@@ -19,7 +19,7 @@
 #define _CRT_SECURE_NO_DEPRECATE
 
 #include <math.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include "headers.h"
 #include "infil.h"
 #include "exfil.h"

--- a/src/hash.c
+++ b/src/hash.c
@@ -15,7 +15,7 @@
 //      HTfree()   - frees a hash table
 //-----------------------------------------------------------------------------
 
-#include <malloc.h>
+#include <stdlib.h>
 #include <string.h>
 #include "hash.h"
 #define UCHAR(x) (((x) >= 'a' && (x) <= 'z') ? ((x)&~32) : (x))

--- a/src/infil.c
+++ b/src/infil.c
@@ -27,8 +27,7 @@
 #define _CRT_SECURE_NO_DEPRECATE
 
 #include <math.h>
-#include "malloc.h"
-#include "stdlib.h"
+#include <stdlib.h>
 #include "headers.h"
 #include "infil.h"
 

--- a/src/input.c
+++ b/src/input.c
@@ -17,7 +17,7 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <math.h>
 #include "headers.h"
 #include "lid.h"

--- a/src/mathexpr.c
+++ b/src/mathexpr.c
@@ -44,7 +44,7 @@
 #define _CRT_SECURE_NO_DEPRECATE
 
 #include <ctype.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <string.h>
 #include <stdlib.h>
 #include <math.h>

--- a/src/mempool.c
+++ b/src/mempool.c
@@ -17,7 +17,7 @@
 
 
 #include <stdlib.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include "mempool.h"
 
 /*

--- a/src/node.c
+++ b/src/node.c
@@ -26,7 +26,7 @@
 //-----------------------------------------------------------------------------
 #define _CRT_SECURE_NO_DEPRECATE
 
-#include <malloc.h>
+#include <stdlib.h>
 #include <string.h>
 #include <math.h>
 #include "headers.h"

--- a/src/project.c
+++ b/src/project.c
@@ -43,7 +43,7 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <math.h>                                                              //(5.1.008)
 #include <omp.h>                                                               //(5.1.008)
 #include "headers.h"

--- a/src/rdii.c
+++ b/src/rdii.c
@@ -24,7 +24,7 @@
 
 #include <math.h>
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include "headers.h"
 
 //-----------------------------------------------------------------------------

--- a/src/report.c
+++ b/src/report.c
@@ -27,7 +27,7 @@
 //-----------------------------------------------------------------------------
 #define _CRT_SECURE_NO_DEPRECATE
 
-#include <malloc.h>
+#include <stdlib.h>
 #include <string.h>
 #include <math.h>
 #include <time.h>

--- a/src/runoff.c
+++ b/src/runoff.c
@@ -25,7 +25,7 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include "headers.h"
 #include "odesolve.h"
 

--- a/src/statsrpt.c
+++ b/src/statsrpt.c
@@ -21,7 +21,7 @@
 //-----------------------------------------------------------------------------
 #define _CRT_SECURE_NO_DEPRECATE
 
-#include <malloc.h>
+#include <stdlib.h>
 #include <string.h>
 #include <math.h>
 #include <time.h>

--- a/src/swmm5.c
+++ b/src/swmm5.c
@@ -293,10 +293,12 @@ int DLLEXPORT swmm_open(char* f1, char* f2, char* f3)
 //  Purpose: opens a SWMM project.
 //
 {
+#ifndef __APPLE__
 #ifdef DLL
    _fpreset();              
 #endif
-
+#endif
+  
 #ifdef EXH
     // --- begin exception handling here
     __try


### PR DESCRIPTION
attempts to address #22 and #20 - although I'm not totally sure I've got all the right `#define`s in the right places to compile the library and the executable. Ideally the executable would be broken out into a separate (very small) unit and either statically or dynamically linked to the library.

I was able to build using something like:
```
cd build
mkdir products && cd products
cmake .. -D CMAKE_C_COMPILER="/usr/local/bin/gcc-6" ..
make && make install
```