### PR TITLE
PR: Add conda recipes and organize folders

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,8 @@ IF(APPLE)
 ENDIF(APPLE)
 
 # includes and source files
-include_directories(../src)
-file(GLOB SWMM_SOURCES ../src/*.c)
+include_directories(src)
+file(GLOB SWMM_SOURCES src/*.c)
 
 # library
 add_library(swmm5 SHARED ${SWMM_SOURCES})
@@ -28,8 +28,7 @@ add_executable(run-swmm ${SWMM_SOURCES})
 target_compile_definitions(run-swmm PRIVATE CLE=TRUE)
 target_link_libraries(run-swmm m pthread)
 
-
 # install
-install(TARGETS swmm5 DESTINATION lib)
 install(TARGETS run-swmm DESTINATION bin)
-install(FILES ../src/swmm5.h DESTINATION include)
+install(TARGETS swmm5 DESTINATION lib)
+install(FILES src/swmm5.h DESTINATION include)

--- a/conda.recipe/bld.bat
+++ b/conda.recipe/bld.bat
@@ -1,0 +1,13 @@
+setlocal EnableDelayedExpansion
+
+:: Make build directory and change to it
+mkdir build
+cd build
+
+:: Configure using the CMakeFiles
+%LIBRARY_BIN%\cmake -G "MSYS Makefiles" -DCMAKE_INSTALL_PREFIX:PATH="%LIBRARY_PREFIX%" -DCMAKE_BUILD_TYPE:STRING=Release ..
+if errorlevel 1 exit 1
+
+:: Build and install
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Make build directory and change to it
+mkdir build
+cd build
+
+# Configure using the CMakeFiles
+cmake -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_BUILD_TYPE:STRING=Release ..
+
+# Build
+make -j $CPU_COUNT
+
+# Install
+make install

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "libswmm" %}
+{% set version = "5.1.13" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  git_url: ../
+  git_tag: HEAD
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - cmake
+    - gcc  # [unix]
+    - m2-make  # [win]
+    - m2-filesystem  # [win]
+    - m2w64-toolchain  # [win]
+    - msys2-conda-epoch >=20160418  # [win]
+  run:
+    - libgcc  # [unix]
+    - m2w64-gcc-libs  # [win]
+    - msys2-conda-epoch >=20160418  # [win]
+
+test:
+  commands:
+    - run-swmm
+
+about:
+  home: https://github.com/OpenWaterAnalytics/Stormwater-Management-Model
+  license_family: MIT
+  license: MIT
+  license_file: LICENSE.txt
+  summary: ORD Stormwater Management Model (aka SWMM).
+  description: |
+    SWMM is a dynamic hydrology-hydraulic water quality simulation model.
+    It is used for single event or long-term (continuous) simulation of
+    runoff quantity and quality from primarily urban areas. SWMM source
+    code is written in the C Programming Language and released in the
+    Public Domain.
+  dev_url: https://github.com/OpenWaterAnalytics/Stormwater-Management-Model
+
+extra:
+  recipe-maintainers:
+    - goanpeca
+    - bemcdonnell

--- a/src/infil.c
+++ b/src/infil.c
@@ -32,7 +32,7 @@
 #define _CRT_SECURE_NO_DEPRECATE
 
 #include <math.h>
-#include "<stdlib.h>"
+#include <stdlib.h>
 #include "headers.h"
 #include "infil.h"
 

--- a/src/swmm5.c
+++ b/src/swmm5.c
@@ -291,7 +291,7 @@ int DLLEXPORT swmm_open(char* f1, char* f2, char* f3)
 //  Purpose: opens a SWMM project.
 //
 {
-#ifndef __APPLE__
+#ifndef __unix__
 #ifdef DLL
    _fpreset();              
 #endif


### PR DESCRIPTION
The build folder should not be bundled with the package and CMakeLists.txt is normally located on the root. The build folder should be generated for every time a new build is made (out of source) which keeps the project clean and allows for quickly deleting unwanted builds.

Since we are now using CMake it really does not make any sense to keep the old makefiles. Whatever changes are needed for the build process should only be made on the CMakeLists.txt file.

Works on:
- [x] Linux
- [x] Osx
- [x] Windows
