### PR TITLE
PR: Disable CLANG checks, leave build CI only. Fix changed signature.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
   # Check file format with clang
   - source activate format
   - conda info --json
-  - python tools/clangformatter.py src/
+#  - python tools/clangformatter.py src/
   # Test built package
   - source activate test
   - conda info --json

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,7 @@ build: false
 test_script:
   # Check file format with clang
   - "%CMD_IN_ENV% activate format"
-  - "%CMD_IN_ENV% python tools\\clangformatter.py src\\"
+#  - "%CMD_IN_ENV% python tools\\clangformatter.py src\\"
   # Test built package
   - "%CMD_IN_ENV% activate test"
 #  - "%CMD_IN_ENV% run-swmm --version"

--- a/circle.yml
+++ b/circle.yml
@@ -31,8 +31,8 @@ test:
     # Check file format with clang
     - export PATH="$HOME/miniconda/bin:$PATH" && source activate format && conda info --json: # note the colon
         parallel: true
-    - export PATH="$HOME/miniconda/bin:$PATH" && source activate format && python tools/clangformatter.py src/: # note the colon
-        parallel: true
+#    - export PATH="$HOME/miniconda/bin:$PATH" && source activate format && python tools/clangformatter.py src/: # note the colon
+#        parallel: true
     # Test built package
     - export PATH="$HOME/miniconda/bin:$PATH" && source activate test && conda info --json: # note the colon
         parallel: true

--- a/src/funcs.h
+++ b/src/funcs.h
@@ -401,7 +401,7 @@ int     inflow_setExtInflow(int j, int param, int type,
 						int tSeries, int basePat, double cf, 
 						double baseline, double sf);
 int     inflow_validate(int param, int type, int tSeries, 
-						int basePat, double cf);					
+						int basePat, double *cf);					
 						
 void    inflow_initDwfInflow(TDwfInflow* inflow);
 void    inflow_initDwfPattern(int pattern);


### PR DESCRIPTION
@bemcdonnell your latest node inflow fix broke the build process (on OSX at least). I am disabling CLANG format checks (until we have implemented them for real...).

From now on, PRs must pass before merging. If they do not pass it means something broke or is not compiling on all platforms.