### PR TITLE
[wip] toolkitapi.h code format

### DIFF
--- a/src/toolkitAPI.h
+++ b/src/toolkitAPI.h
@@ -34,20 +34,6 @@ extern "C" {
 void DLLEXPORT swmm_getAPIError(int errcode, char *s);
 
 // Input API Exportable Functions
-/**
- @brief runs a complete EPANET simulation
- @param inpFile pointer to name of input file (must exist)
- @param rptFile pointer to name of report file (to be created)
- @param binOutFile pointer to name of binary output file (to be created)
- @param callback a callback function that takes a character string (char *) as
- its only parameter.
- @return error code
-
- The callback function should reside in and be used by the calling
- code to display the progress messages that EPANET generates
- as it carries out its computations. If this feature is not
- needed then the argument should be NULL.
- */
 int DLLEXPORT swmm_getSimulationUnit(int type, int *value);
 int DLLEXPORT swmm_getSimulationAnalysisSetting(int type, int *value);
 int DLLEXPORT swmm_getSimulationParam(int type, double *value);

--- a/src/toolkitAPI.h
+++ b/src/toolkitAPI.h
@@ -34,6 +34,20 @@ extern "C" {
 void DLLEXPORT swmm_getAPIError(int errcode, char *s);
 
 // Input API Exportable Functions
+/**
+ @brief runs a complete EPANET simulation
+ @param inpFile pointer to name of input file (must exist)
+ @param rptFile pointer to name of report file (to be created)
+ @param binOutFile pointer to name of binary output file (to be created)
+ @param callback a callback function that takes a character string (char *) as
+ its only parameter.
+ @return error code
+
+ The callback function should reside in and be used by the calling
+ code to display the progress messages that EPANET generates
+ as it carries out its computations. If this feature is not
+ needed then the argument should be NULL.
+ */
 int DLLEXPORT swmm_getSimulationUnit(int type, int *value);
 int DLLEXPORT swmm_getSimulationAnalysisSetting(int type, int *value);
 int DLLEXPORT swmm_getSimulationParam(int type, double *value);

--- a/src/toolkitAPI.h
+++ b/src/toolkitAPI.h
@@ -14,53 +14,54 @@
 
 //#ifndef DLLEXPORT
 #ifdef WINDOWS
-	#ifdef __MINGW32__
-		// <- More wrapper friendly
-		#define DLLEXPORT __declspec(dllexport) __cdecl 
-	#else
-		#define DLLEXPORT __declspec(dllexport) __stdcall
-	#endif
+#ifdef __MINGW32__
+// <- More wrapper friendly
+#define DLLEXPORT __declspec(dllexport) __cdecl
 #else
-	#define DLLEXPORT
+#define DLLEXPORT __declspec(dllexport) __stdcall
 #endif
-//#endif 
+#else
+#define DLLEXPORT
+#endif
+//#endif
 
 #ifdef __cplusplus
-extern "C" { 
-#endif 
+extern "C" {
+#endif
 
 #define _CRT_SECURE_NO_DEPRECATE
 
 void DLLEXPORT swmm_getAPIError(int errcode, char *s);
 
 // Input API Exportable Functions
-int DLLEXPORT  swmm_getSimulationUnit(int type, int *value);
-int DLLEXPORT  swmm_getSimulationAnalysisSetting(int type, int *value);
-int DLLEXPORT  swmm_getSimulationParam(int type, double *value);
+int DLLEXPORT swmm_getSimulationUnit(int type, int *value);
+int DLLEXPORT swmm_getSimulationAnalysisSetting(int type, int *value);
+int DLLEXPORT swmm_getSimulationParam(int type, double *value);
 
-int DLLEXPORT  swmm_countObjects(int type, int *count);
-int DLLEXPORT  swmm_getObjectId(int type, int index, char *id);
+int DLLEXPORT swmm_countObjects(int type, int *count);
+int DLLEXPORT swmm_getObjectId(int type, int index, char *id);
 
-int DLLEXPORT  swmm_getNodeType(int index, int *Ntype);
-int DLLEXPORT  swmm_getLinkType(int index, int *Ltype);
+int DLLEXPORT swmm_getNodeType(int index, int *Ntype);
+int DLLEXPORT swmm_getLinkType(int index, int *Ltype);
 
-int DLLEXPORT  swmm_getLinkConnections(int index, int *Node1, int *Node2);
-int DLLEXPORT  swmm_getSubcatchOutConnection(int index, int *type, int *Index );
+int DLLEXPORT swmm_getLinkConnections(int index, int *Node1, int *Node2);
+int DLLEXPORT swmm_getSubcatchOutConnection(int index, int *type, int *Index);
 
-//Nodes
-int DLLEXPORT  swmm_getNodeParam(int index, int Param, double *value);
-int DLLEXPORT  swmm_setNodeParam(int index, int Param, double value);
-//Links
-int DLLEXPORT  swmm_getLinkParam(int index, int Param, double *value);
-int DLLEXPORT  swmm_setLinkParam(int index, int Param, double value);
-int DLLEXPORT  swmm_getLinkDirection(int index, signed char *value);
-//Subcatchments
-int DLLEXPORT  swmm_getSubcatchParam(int index, int Param, double *value);
-int DLLEXPORT  swmm_setSubcatchParam(int index, int Param, double value);
-// 
-int DLLEXPORT swmm_getSimulationDateTime(int timetype, int *year, int *month, int *day,
-	int *hour, int *minute, int *seconds);
-int DLLEXPORT  swmm_setSimulationDateTime(int timetype, char *dtimestr);
+// Nodes
+int DLLEXPORT swmm_getNodeParam(int index, int Param, double *value);
+int DLLEXPORT swmm_setNodeParam(int index, int Param, double value);
+// Links
+int DLLEXPORT swmm_getLinkParam(int index, int Param, double *value);
+int DLLEXPORT swmm_setLinkParam(int index, int Param, double value);
+int DLLEXPORT swmm_getLinkDirection(int index, signed char *value);
+// Subcatchments
+int DLLEXPORT swmm_getSubcatchParam(int index, int Param, double *value);
+int DLLEXPORT swmm_setSubcatchParam(int index, int Param, double value);
+//
+int DLLEXPORT swmm_getSimulationDateTime(int timetype, int *year, int *month,
+                                         int *day, int *hour, int *minute,
+                                         int *seconds);
+int DLLEXPORT swmm_setSimulationDateTime(int timetype, char *dtimestr);
 
 //-------------------------------
 // Active Simulation Results API
@@ -86,8 +87,6 @@ int DLLEXPORT swmm_getSystemRunoffStats(TRunoffTotals *runoffTot);
 int DLLEXPORT swmm_setLinkSetting(int index, double setting);
 int DLLEXPORT swmm_setNodeInflow(int index, double flowrate);
 
-#ifdef __cplusplus 
-}   // matches the linkage specification from above */ 
+#ifdef __cplusplus
+}    // matches the linkage specification from above */
 #endif
-
-

--- a/tools/clangformatter.py
+++ b/tools/clangformatter.py
@@ -89,7 +89,6 @@ FILES_FAILING_FORMAT_CHECK = [
     'src/table.c',
     'src/text.h',
     'src/toolkitAPI.c',
-    'src/toolkitAPI.h',
     'src/toposort.c',
     'src/transect.c',
     'src/treatmnt.c',


### PR DESCRIPTION
@goanpeca, there is an issue with the formatter. I've added some test API documentation from the EPANET project.  


```C
+void DLLEXPORT swmm_getAPIError(int errcode, char *s);
+
+// Input API Exportable Functions
+/**
+ @brief runs a complete EPANET simulation
+ @param inpFile pointer to name of input file (must exist)
+ @param rptFile pointer to name of report file (to be created)
+ @param binOutFile pointer to name of binary output file (to be created)
+ @param callback a callback function that takes a character string (char *) as
+ its only parameter.
+ @return error code
+
+ The callback function should reside in and be used by the calling
+ code to display the progress messages that EPANET generates
+ as it carries out its computations. If this feature is not
+ needed then the argument should be NULL.
+ */
+int DLLEXPORT swmm_getSimulationUnit(int type, int *value);
```