### PR TITLE
API Version Tracker

### DIFF
--- a/src/consts.h
+++ b/src/consts.h
@@ -18,8 +18,11 @@
 #define   VERSION            52000          // Eventually will be deprecated. 
 #define   SEMVERSION_MAJOR   "5"            // Major Semantic Version
 #define   SEMVERSION_MINOR   "2"            // Minor Semantic Version
-#define   SEMVERSION_PATCH   "0.dev1"      // Patch Semantic Version
+#define   SEMVERSION_PATCH   "0.dev1"       // Patch Semantic Version
 #define   SEMVERSION_LEN     20             // Version String Len
+#define   API_VERSION_MAJOR  "2"            // API Major Version Number
+#define   API_VERSION_MINOR  "0.dev0"       // API Minor Version Number
+
 
 #define   MAGICNUMBER        516114522
 #define   EOFMARK            0x1A           // Use 0x04 for UNIX systems

--- a/src/funcs.h
+++ b/src/funcs.h
@@ -562,3 +562,4 @@ DateTime getDateTime(double elapsedMsec);     // convert elapsed time to date
 void     getElapsedTime(DateTime aDate,       // convert elapsed date
          int* days, int* hrs, int* mins);
 void     getSemVersion(char* semver);         // get semantic version
+void     getAPIVersion(char* apiver);         // get API version

--- a/src/swmm5.c
+++ b/src/swmm5.c
@@ -753,7 +753,7 @@ void DLLEXPORT swmm_getSemVersion(char* semver)
 //  
 //  NOTE: Each New Release should be updated in consts.h
 {
-	getSemVersion(semver);
+    getSemVersion(semver);
 }
 
 void DLLEXPORT swmm_getVersionInfo(char* major, char* minor, char* patch)
@@ -763,11 +763,31 @@ void DLLEXPORT swmm_getVersionInfo(char* major, char* minor, char* patch)
 //  
 //  NOTE: Each New Release should be updated in consts.h
 {
-	strncpy(major, SEMVERSION_MAJOR, sizeof SEMVERSION_MAJOR);
-	strncpy(minor, SEMVERSION_MINOR, sizeof SEMVERSION_MINOR);
-	strncpy(patch, SEMVERSION_PATCH, sizeof SEMVERSION_PATCH);
+    strncpy(major, SEMVERSION_MAJOR, sizeof SEMVERSION_MAJOR);
+    strncpy(minor, SEMVERSION_MINOR, sizeof SEMVERSION_MINOR);
+    strncpy(patch, SEMVERSION_PATCH, sizeof SEMVERSION_PATCH);
 }
 
+void DLLEXPORT swmm_getAPIVersion(char* apiver)
+//
+//  Output: Returns API Version
+//  Purpose: retrieves the current API version
+//  
+//  NOTE: Each New Release should be updated in consts.h
+{
+    getAPIVersion(apiver);
+}
+
+void DLLEXPORT swmm_getAPIVersionInfo(char* major, char* minor)
+//
+//  Output: Returns API Version Info
+//  Purpose: retrieves the current API version
+//  
+//  NOTE: Each New Release should be updated in consts.h
+{
+    strncpy(major, API_VERSION_MAJOR, sizeof API_VERSION_MAJOR);
+    strncpy(minor, API_VERSION_MINOR, sizeof API_VERSION_MINOR);
+}
 //=============================================================================
 
 ////  New function added to release 5.1.011.  ////                             //(5.1.011)
@@ -1058,8 +1078,18 @@ void getSemVersion(char* semver)
 //  
 //  NOTE: Each New Release should be updated in consts.h
 {
-	snprintf(semver, SEMVERSION_LEN, "%s.%s.%s", 
-		SEMVERSION_MAJOR, SEMVERSION_MINOR, SEMVERSION_PATCH);
+    snprintf(semver, SEMVERSION_LEN, "%s.%s.%s", 
+        SEMVERSION_MAJOR, SEMVERSION_MINOR, SEMVERSION_PATCH);
 }
 
+void getAPIVersion(char* apiver)
+//
+//  Output: Returns API Version
+//  Purpose: retrieves the current semantic version
+//  
+//  NOTE: Each New API Release should be updated in consts.h
+{
+    snprintf(apiver, SEMVERSION_LEN, "%s.%s", 
+        API_VERSION_MAJOR, API_VERSION_MINOR);
+}
 //=============================================================================

--- a/src/swmm5.h
+++ b/src/swmm5.h
@@ -56,6 +56,8 @@ int  DLLEXPORT   swmm_getMassBalErr(float* runoffErr, float* flowErr,
 int  DLLEXPORT   swmm_close(void);
 int  DLLEXPORT   swmm_getVersion(void);
 void DLLEXPORT   swmm_getSemVersion(char* semver);
+void DLLEXPORT   swmm_getAPIVersion(char* apiver);
+void DLLEXPORT   swmm_getAPIVersionInfo(char* major, char* minor);
 void DLLEXPORT   swmm_getVersionInfo(char* major, char* minor, char* patch);
 int  DLLEXPORT   swmm_getError(char* errMsg, int msgLen);                      //(5.1.011)
 int  DLLEXPORT   swmm_getWarnings(void);                                       //(5.1.011)


### PR DESCRIPTION
Closes #98 

I am supportive of a community of people that are very 'used' to SWMM's versioning strategy.  I am confident that the community will move toward adopting proper semantic versioning... but in the mean time, since the API is going to be rapidly growing, @michaeltryby and I think it would be a good idea to start tracking the API version, separately.   Arguably, I'm imagining that not everyone will agree with this versioning philosophy. However, instead of bumping up SWMM's minor version number each time we add a few API functions, this will hopefully keep the community from wondering why SWMM's minor version keeps increasing, but the normal user doesn't get to leverage such functions. 

Instead of having a full semantic number for the API, I just have a major and minor number.  The major number will be bumped up each time a new set of functions are introduced to the API and the minor will consist of patches and bug fixes to the API. 

So currently we are sitting on: `v2.0.dev0`

API `v1.0` can be considered the original collection of API functions in `swmm.h`.

This pull request introduces two functions to fetch the API version.

In addition, we have some housekeeping (converting my dreaded tabs to spaces........)