### PR TITLE
Add surfaceArea to node parameters

### DIFF
--- a/src/node.c
+++ b/src/node.c
@@ -381,7 +381,7 @@ double  node_getSurfArea(int j, double d)
     switch (Node[j].type)
     {
       case STORAGE: return storage_getSurfArea(j, d);
-      default:      return 0.0;        
+      default:      return Node[j].surfaceArea;
     }
 }
 

--- a/src/node.c
+++ b/src/node.c
@@ -363,7 +363,7 @@ double node_getVolume(int j, double d)
 
       default:
         if ( Node[j].fullDepth > 0.0 )
-            return Node[j].fullVolume * (d / Node[j].fullDepth);
+            return Node[j].surfaceArea * d;
         else return 0.0;
     }
 }

--- a/src/objects.h
+++ b/src/objects.h
@@ -499,6 +499,7 @@ typedef struct
    double        fullDepth;       // dist. from invert to surface (ft)
    double        surDepth;        // added depth under surcharge (ft)
    double        pondedArea;      // area filled by ponded water (ft2)
+   double        surfaceArea;     // area used to calculate node's volume (ft2)
    TExtInflow*   extInflow;       // pointer to external inflow data
    TDwfInflow*   dwfInflow;       // pointer to dry weather flow inflow data
    TRdiiInflow*  rdiiInflow;      // pointer to RDII inflow data

--- a/src/toolkitAPI.c
+++ b/src/toolkitAPI.c
@@ -409,7 +409,7 @@ int DLLEXPORT swmm_setNodeParam(int index, int Param, double value)
 		// surfaceArea
 		case 5:
 			Node[index].surfaceArea = value / UCF(LENGTH) * UCF(LENGTH);
-			Node[index].fullVolume = Node[index].surfaceArea * Node[index].fullDepth;
+			Node[index].fullVolume = node_getVolume(index, Node[index].fullDepth);
 			break;
 		// Type not available
 		default: return(ERR_API_OUTBOUNDS);

--- a/src/toolkitAPI.c
+++ b/src/toolkitAPI.c
@@ -407,7 +407,10 @@ int DLLEXPORT swmm_setNodeParam(int index, int Param, double value)
 		// initDepth
 		case 4: Node[index].initDepth = value / UCF(LENGTH); break;
 		// surfaceArea
-		case 5: Node[index].surfaceArea = value / UCF(LENGTH) * UCF(LENGTH); break;
+		case 5:
+			Node[index].surfaceArea = value / UCF(LENGTH) * UCF(LENGTH);
+			Node[index].fullVolume = Node[index].surfaceArea * Node[index].fullDepth;
+			break;
 		// Type not available
 		default: return(ERR_API_OUTBOUNDS);
 	}

--- a/src/toolkitAPI.c
+++ b/src/toolkitAPI.c
@@ -371,6 +371,8 @@ int DLLEXPORT swmm_getNodeParam(int index, int Param, double *value)
 		case 3: *value = Node[index].pondedArea * UCF(LENGTH) * UCF(LENGTH); break;
 		// initDepth
 		case 4: *value = Node[index].initDepth * UCF(LENGTH); break;
+		// surfaceArea
+		case 5: *value = Node[index].surfaceArea * UCF(LENGTH) * UCF(LENGTH); break;
 		// Type not available
 		default: return(ERR_API_OUTBOUNDS);
 	}
@@ -404,6 +406,8 @@ int DLLEXPORT swmm_setNodeParam(int index, int Param, double value)
 		case 3: Node[index].pondedArea = value / ( UCF(LENGTH) * UCF(LENGTH) ); break;
 		// initDepth
 		case 4: Node[index].initDepth = value / UCF(LENGTH); break;
+		// surfaceArea
+		case 5: Node[index].surfaceArea = value / UCF(LENGTH) * UCF(LENGTH); break;
 		// Type not available
 		default: return(ERR_API_OUTBOUNDS);
 	}


### PR DESCRIPTION
Add surfaceArea to TNode struct.
node_getSurfArea() returns that value by default.
Update toolkitAPI to get and set surfaceArea, and update fullVolume when updating surfaceArea.

See issue #112.