### PR TITLE
[WIP]: Test nrtest on circleci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,46 +1,25 @@
 # https://circleci.com/gh/OpenWaterAnalytics/Stormwater-Management-Model/
 
-machine:
-  environment:
-    # Environment variables used by astropy helpers
-    TRAVIS_OS_NAME:        "linux"
-    TRAVIS_PYTHON_VERSION: "3.6"
-    # Conda variables and aliases for commands
-    CMD_CONDA:        /home/ubuntu/miniconda/bin/conda
-    CMD_TEST_PYTHON:  /home/ubuntu/miniconda/envs/test/bin/python
-    PATH:             /home/ubuntu/miniconda/bin:$PATH
+checkout:
+  override:
+    # The code to run the regression tests is on a specific branch
+    - git clone --depth=50 --branch=feature-nrtest https://github.com/OpenWaterAnalytics/Stormwater-Management-Model.git
 
 dependencies:
-  cache_directories:
-    - "~/condacache/pkgs"
-    - "~/.cache/pip"
+  pre:
+    # We need cmake 3.x
+    - sudo add-apt-repository ppa:george-edison55/cmake-3.x -y
   override:
-    # Use Astropy ci helpers for initial setup
-    - git clone git://github.com/astropy/ci-helpers.git
-    - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
-    # Install dependencies
-    - $CMD_CONDA update -n root conda -q --no-pin;
-    - $CMD_CONDA install -n root conda-build anaconda-client -q --no-pin;
-    - $CMD_CONDA config --add pkgs_dirs ~/condacache/pkgs;
-    - $CMD_CONDA create -n format clangdev -c conda-forge
-    - conda-build conda.recipe;
-    - $CMD_CONDA install -n test libswmm --use-local;
+    - sudo apt update
+    - sudo apt install --only-upgrade cmake
+    - pip install --upgrade pip
+    - pip install wheel
+    - cd Stormwater-Management-Model; pip install --src buildprod/packages -r tools/requirements.txt
+
+compile:
+  override:
+    - cd Stormwater-Management-Model/buildprod; cmake -DCMAKE_BUILD_TYPE=Release ..; cmake --build . --config Release
 
 test:
   override:
-    # Check file format with clang
-    - export PATH="$HOME/miniconda/bin:$PATH" && source activate format && conda info --json: # note the colon
-        parallel: true
-    - export PATH="$HOME/miniconda/bin:$PATH" && source activate format && python tools/clangformatter.py src/: # note the colon
-        parallel: true
-    # Test built package
-    - export PATH="$HOME/miniconda/bin:$PATH" && source activate test && conda info --json: # note the colon
-        parallel: true
-    - export PATH="$HOME/miniconda/bin:$PATH" && source activate test && run-swmm --help: # note the colon
-        parallel: true
-
-deployment:
-  develop:
-    branch: develop
-    commands:
-      - export PATH="$HOME/miniconda/bin:$PATH" && source activate root && conda-build conda.recipe --user owa --token $SWWM_CI_UPLOAD_TOKEN --old-build-string;
+    - cd Stormwater-Management-Model; tools/gen-config.sh `pwd`/buildprod/bin > ./tests/apps/swmm-<build id>.json; tools/run-nrtest.sh `pwd`/tests/swmm-nrtestsuite 5112

--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,14 @@
 # https://circleci.com/gh/OpenWaterAnalytics/Stormwater-Management-Model/
 
+environment:
+  SWMM_HOME: /home/ubuntu/Stormwater-Management-Model/Stormwater-Management-Model/
+  BUILD_HOME: build
+  TEST_HOME: tests/swmm-nrtestsuite
+
 checkout:
   override:
     # The code to run the regression tests is on a specific branch
-    - git clone --depth=50 --branch=feature-nrtest https://github.com/OpenWaterAnalytics/Stormwater-Management-Model.git
+    - cd ..; git clone --depth=50 --branch=feature-nrtest https://github.com/OpenWaterAnalytics/Stormwater-Management-Model.git
 
 dependencies:
   pre:
@@ -18,8 +23,8 @@ dependencies:
 
 compile:
   override:
-    - cd Stormwater-Management-Model/buildprod; cmake -DCMAKE_BUILD_TYPE=Release ..; cmake --build . --config Release
+    - cd Stormwater-Management-Model; mkdir build; cd build; cmake ..; make
 
 test:
   override:
-    - cd Stormwater-Management-Model; tools/gen-config.sh `pwd`/buildprod/bin > ./tests/apps/swmm-<build id>.json; tools/run-nrtest.sh `pwd`/tests/swmm-nrtestsuite 5112
+    - cd Stormwater-Management-Model; tools/gen-config.sh $SWMM_HOME/$BUILD_HOME/bin > $TEST_HOME/apps/swmm-$CIRCLE_SHA1.json

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,7 @@ environment:
 checkout:
   override:
     # The code to run the regression tests is on a specific branch
-    - cd ..; git clone --depth=50 --branch=feature-nrtest https://github.com/OpenWaterAnalytics/Stormwater-Management-Model.git
+    - git clone --depth=50 --branch=feature-nrtest https://github.com/OpenWaterAnalytics/Stormwater-Management-Model.git
 
 dependencies:
   pre:
@@ -23,7 +23,7 @@ dependencies:
 
 compile:
   override:
-    - cd Stormwater-Management-Model; mkdir build; cd build; cmake ..; make
+    - cd Stormwater-Management-Model; mkdir $BUILD_HOME; cd $BUILD_HOME; cmake ..; make
 
 test:
   override:


### PR DESCRIPTION
Hi @michaeltryby I am trying to implement the instructions described on -> https://github.com/OpenWaterAnalytics/Stormwater-Management-Model/tree/feature-nrtest/tests

For the Circle ci default container (Ubuntu 14.04).

See the build - > https://circleci.com/gh/OpenWaterAnalytics/Stormwater-Management-Model/258

At the moment when running the commands it yields:

```
$ cd Stormwater-Management-Model; tools/gen-config.sh `pwd`/buildprod/bin > ./tests/apps/swmm-<build id>.json; tools/run-nrtest.sh `pwd`/tests/swmm-nrtestsuite 5112
bash: line 1: ./tests/apps/swmm-: No such file or directory
INFO: Creating test benchmark
INFO: nrtest execute apps/swmm-5112.json tests/examples -o benchmark/swmm-5112
ERROR: Unable to find executable: "C:/Users/mtryby/bin/swmm5112.exe"

INFO: Comparing test and ref benchmarks
INFO: nrtest compare benchmark/swmm-5112 benchmark/swmm-5112 --rtol 0.01 --atol 0.0
Traceback (most recent call last):
  File "/opt/circleci/.pyenv/versions/2.7.11/bin/nrtest", line 6, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "/home/ubuntu/Stormwater-Management-Model/Stormwater-Management-Model/buildprod/packages/nrtest/scripts/nrtest", line 106, in <module>
    args.func(args)
  File "/home/ubuntu/Stormwater-Management-Model/Stormwater-Management-Model/buildprod/packages/nrtest/scripts/nrtest", line 51, in compare
    ts_new = TestSuite.read_benchmark(args.new)
  File "/home/ubuntu/Stormwater-Management-Model/Stormwater-Management-Model/buildprod/packages/nrtest/nrtest/testsuite.py", line 62, in read_benchmark
    with open(manifest_path) as f:
IOError: [Errno 2] No such file or directory: 'benchmark/swmm-5112/manifest.json'

cd Stormwater-Management-Model; tools/gen-config.sh `pwd`/buildprod/bin > ./tests/apps/swmm-<build id>.json; tools/run-nrtest.sh `pwd`/tests/swmm-nrtestsuite 5112 returned exit code 1
```

This looks similar to issue reported at https://github.com/OpenWaterAnalytics/Stormwater-Management-Model/issues/117 by @lrntct