### PR TITLE
Broken link to regression testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See [CONTRIBUTING.md](https://github.com/OpenWaterAnalytics/Stormwater-Managemen
 
 # Regression Testing
 
-To run the test suite for please refer to the [tests/README.md](https://github.com/OpenWaterAnalytics/Stormwater-Management-Model/blob/feature-nrtest/tests/README.md)
+To run the test suite for please refer to the [tests/README.md](https://github.com/OpenWaterAnalytics/Stormwater-Management-Model/blob/develop/tests/README.md)
 
 # Code of conduct
 


### PR DESCRIPTION
Closes #139 
Changed URL in link to regression testing instructions.