### PR TITLE
AppVeyor: Decouple swmm-output python extension build from main project

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -78,27 +78,22 @@ init:
   - echo %BOOST_LIB%
 
 install:
-  # Install SWIG using chocolatey
-  - choco install swig
-  - swig -version
-  # `C:\Python27` (x86) is default on path for `python` command
-  - python --version
+  # Install nrtest and dependencies for regression tests
+  - python -m pip install -r tools\requirements-appveyor.txt
 
 before_build:
+  - mkdir %BUILD_HOME%
+  - cd %BUILD_HOME%
   - cmake -G %GENERATOR% 
     -DBOOST_ROOT="%BOOST_ROOT%"
     -DBOOST_LIBRARYDIR="%BOOST_LIB%"
     -DBoost_USE_STATIC_LIBS="ON"
-    -DCMAKE_INSTALL_PREFIX:PATH=%BUILD_HOME% 
     -DCMAKE_BUILD_TYPE:STRING=Release
 
 build_script:
   - cmake --build . --config Release
 
 before_test: 
-  # Install nrtest and dependencies for regression tests
-  - python -m pip install --src %BUILD_HOME%\packages -r tools\requirements.txt
-  # 
   - cd %SWMM_HOME%
   - tools\gen-config.cmd %SWMM_HOME%\bin\Release > %TEST_HOME%\apps\swmm-%APPVEYOR_REPO_COMMIT%.json
 
@@ -106,10 +101,10 @@ test_script:
   # run unit tests
   - cd %SWMM_HOME%\tests
   - ctest -C Release
+    # Run regression tests
   - cd %SWMM_HOME%
-  # Run regression tests
   - tools\run-nrtest.cmd %NRTEST_SCRIPT% %TEST_HOME% %APPVEYOR_REPO_COMMIT%
 
-cache:
-  - C:\ProgramData\chocolatey\bin -> appveyor.yml
-  - C:\ProgramData\chocolatey\lib -> appveyor.yml
+#cache:
+#  - C:\ProgramData\chocolatey\bin -> appveyor.yml
+#  - C:\ProgramData\chocolatey\lib -> appveyor.yml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -98,7 +98,7 @@ before_test:
 
 test_script:
   # run unit tests
-  - cd %SWMM_HOME%\tests
+  - cd %BUILD_HOME%\tests
   - ctest -C Release
     # Run regression tests
   - cd %SWMM_HOME%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -87,8 +87,7 @@ before_build:
   - cmake -G %GENERATOR% 
     -DBOOST_ROOT="%BOOST_ROOT%"
     -DBOOST_LIBRARYDIR="%BOOST_LIB%"
-    -DBoost_USE_STATIC_LIBS="ON"
-    -DCMAKE_BUILD_TYPE:STRING=Release
+    -DBoost_USE_STATIC_LIBS="ON" ..
 
 build_script:
   - cmake --build . --config Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -94,7 +94,7 @@ build_script:
 
 before_test: 
   - cd %SWMM_HOME%
-  - tools\gen-config.cmd %SWMM_HOME%\bin\Release > %TEST_HOME%\apps\swmm-%APPVEYOR_REPO_COMMIT%.json
+  - tools\gen-config.cmd %SWMM_HOME%\%BUILD_HOME%\bin\Release > %TEST_HOME%\apps\swmm-%APPVEYOR_REPO_COMMIT%.json
 
 test_script:
   # run unit tests

--- a/tools/nrtest-swmm/setup.py
+++ b/tools/nrtest-swmm/setup.py
@@ -38,7 +38,7 @@ setup(
         'header_detail_footer>=2.3',
         'nrtest>=0.2.0',
         'numpy>=1.7.0',
-        'swmm_output>=1.0.0',
+        'swmm_output',
     ],
     keywords='nrtest_swmm'  
 )

--- a/tools/requirements-appveyor.txt
+++ b/tools/requirements-appveyor.txt
@@ -1,0 +1,18 @@
+#
+# requirements-appveyor.txt 
+# 
+# Date Created: 3/15/2018
+# Author: Michael E. Tryby
+#         US EPA ORD/NRMRL
+# 
+# Useful for configuring a python environment to run swmm-nrtestsuite. 
+#
+# command: pip install -r tools/requirements-appveyor.txt
+#
+
+
+nrtest>=0.2.3
+
+-f https://github.com/OpenWaterAnalytics/swmm-python/releases/download/v0.1.0-alpha/swmm_output-0.1.0a0-cp27-cp27m-win32.whl
+
+-e ./tools/nrtest-swmm

--- a/tools/swmm-output/setup.py
+++ b/tools/swmm-output/setup.py
@@ -20,7 +20,7 @@ except ImportError:
 
 setup(
     name = "swmm-output",
-    version = "1.0",
+    version = "0.1.0-alpha",
     ext_modules = [
         Extension("_swmm_output",
             define_macros = [('swmm_output_EXPORTS', None)], 


### PR DESCRIPTION
This PR addresses Issue #165 on AppVeyor. 

Notice how you can accept this PR with a high degree of confidence because the build is clean and the tests are in the green. 