### PR TITLE
Make error_getMsg take an error code, not an index

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -216,10 +216,23 @@ int ErrorCodes[] =
 
 char  ErrString[256];
 
-char* error_getMsg(int i)
+char* error_getMsg(int errcode)
+//
+// Input: errcode = error code
+// Output: error message text
+// Purpose: converts an error code to an error message
+//
 {
-    if ( i >= 0 && i < MAXERRMSG ) return ErrorMsgs[i];
-    else return ErrorMsgs[0];
+    // The user passes an error code.  Given this error code, we find the
+    // corresponding index into the ErrorMsg struct
+    for (int errindex = 0; errindex < MAXERRMSG; errindex++) {
+      if (ErrorCodes[errindex] == errcode) {
+        return ErrorMsgs[errindex];
+      }
+    }
+
+    // If error code is not found, return empty string
+    return ErrorMsgs[0];
 };
 
 int  error_getCode(int i)

--- a/src/error.h
+++ b/src/error.h
@@ -172,6 +172,6 @@ enum  ErrorType {
 	  ERR_API_PATTERN_INDEX,    //509  112
       MAXERRMSG};
       
-char* error_getMsg(int i);
+char* error_getMsg(int errcode);
 int   error_getCode(int i);
 int   error_setInpError(int errcode, char* s);


### PR DESCRIPTION
The `error_getMsg` function assumed that the user was passing not an error code, but an error *index* into the internal `ErrorMsgs` struct.  This is not how the `error_getMsg` function is called elsewhere.  For example, see the [`swmm_getAPIError`](https://github.com/OpenWaterAnalytics/Stormwater-Management-Model/blob/2605fe91a1f08e0d70f8b204fcbc00a7ff0a66af/src/toolkitAPI.c#L42-L51) function.

Now when the user is handed an error code (a member of the `ErrorCodes` struct) from, say [`swmm_open`](https://github.com/OpenWaterAnalytics/Stormwater-Management-Model/blob/2605fe91a1f08e0d70f8b204fcbc00a7ff0a66af/src/swmm5.c#L381), they can directly convert it to a useful message using `error_getMsg` rather than having to know about where it lives inside the `ErrorMsgs` struct.

Let me know if this is not the right approach and, instead, you'd prefer to have a conversion utility that converts an error code into an error index before then passing that index to `error_getMsg`.