### PR TITLE
Simplify command line arguments for reg test helper scripts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,6 @@ init:
   - set SWMM_HOME=%APPVEYOR_BUILD_FOLDER%
   - set BUILD_HOME=buildprod
   - set TEST_HOME=nrtestsuite
-  - set NRTEST_SCRIPT=C:\Python27\Scripts
   # See set values
   - echo %APPVEYOR_BUILD_WORKER_IMAGE%
   - echo %BUILD_HOME%
@@ -41,7 +40,7 @@ install:
 before_build:
   - mkdir %BUILD_HOME%
   - cd %BUILD_HOME%
-  - cmake -G "%GENERATOR%" 
+  - cmake -G "%GENERATOR%"
     -DBUILD_TESTS=1
     -DBOOST_ROOT="%BOOST_ROOT%"
     -DBoost_USE_STATIC_LIBS="ON" ..
@@ -49,9 +48,9 @@ before_build:
 build_script:
   - cmake --build . --config Release
 
-before_test: 
+before_test:
   - cd %SWMM_HOME%
-  - tools\before-test.cmd %TEST_HOME% %SWMM_HOME%\%BUILD_HOME%\bin\Release %APPVEYOR_REPO_COMMIT%
+  - tools\before-test.cmd %APPVEYOR_REPO_COMMIT%
 
 test_script:
   # run unit tests
@@ -59,10 +58,10 @@ test_script:
   - ctest -C Release
     # Run regression tests
   - cd %SWMM_HOME%
-  - tools\run-nrtest.cmd %NRTEST_SCRIPT% %TEST_HOME% %APPVEYOR_REPO_COMMIT%
+  - tools\run-nrtest.cmd %APPVEYOR_REPO_COMMIT%
 
-on_finish: 
-  # zip up the SUT benchmarks 
+on_finish:
+  # zip up the SUT benchmarks
   - 7z a benchmarks.zip %TEST_HOME%\benchmark\swmm-%APPVEYOR_REPO_COMMIT%\
   - appveyor PushArtifact benchmarks.zip -FileName benchmarks
 

--- a/tools/before-test.cmd
+++ b/tools/before-test.cmd
@@ -7,9 +7,8 @@
 ::          US EPA - ORD/NRMRL
 ::
 ::  Arguments:
-::    1 - relative path regression test file staging location
-::    2 - absolute path to location of software under test
-::    3 - build identifier for software under test
+::    1 - build identifier for software under test
+::    2 - (relative path regression test file staging location)
 ::
 ::  Note:
 ::    Tests and benchmark files are stored in the swmm-example-networks repo.
@@ -21,11 +20,26 @@
 @echo off
 setlocal
 
-set SCRIPT_HOME=%~dp0
-set TEST_HOME=%~1
 
+:: CHANGE THESE VARIABLES TO UPDATE BENCHMARK
 set EXAMPLES_VER=1.0.1-dev.5
 set BENCHMARK_VER=520dev5
+
+
+set "SCRIPT_HOME=%~dp0"
+set "EXE_HOME=buildprod\bin\Release"
+
+:: Determine SUT executable path
+for %%a in ("%SCRIPT_HOME:~0,-1%") do set "SUT_PATH=%%~dpa"
+set SUT_PATH=%SUT_PATH%%EXE_HOME%
+
+:: Check existence and apply default arguments
+IF NOT [%1]==[] ( set "SUT_VER=%~1"
+) ELSE ( set "SUT_VER=vXXX" )
+
+IF NOT [%2]==[] ( set "TEST_HOME=%~2"
+) ELSE ( set "TEST_HOME=nrtestsuite" )
+
 
 set TESTFILES_URL=https://github.com/OpenWaterAnalytics/swmm-example-networks/archive/v%EXAMPLES_VER%.zip
 set BENCHFILES_URL=https://github.com/OpenWaterAnalytics/swmm-example-networks/releases/download/v%EXAMPLES_VER%/swmm-benchmark-%BENCHMARK_VER%.zip

--- a/tools/before-test.cmd
+++ b/tools/before-test.cmd
@@ -71,4 +71,4 @@ mklink /D .\tests .\swmm-example-networks-%EXAMPLES_VER%\swmm-tests
 
 :: generate json configuration file for software under test
 mkdir apps
-%SCRIPT_HOME%\gen-config.cmd %SUT_PATH% > apps\swmm-%~3.json
+%SCRIPT_HOME%\gen-config.cmd %SUT_PATH% > apps\swmm-%SUT_VER%.json

--- a/tools/before-test.cmd
+++ b/tools/before-test.cmd
@@ -71,4 +71,4 @@ mklink /D .\tests .\swmm-example-networks-%EXAMPLES_VER%\swmm-tests
 
 :: generate json configuration file for software under test
 mkdir apps
-%SCRIPT_HOME%\gen-config.cmd %~2 > apps\swmm-%~3.json
+%SCRIPT_HOME%\gen-config.cmd %SUT_PATH% > apps\swmm-%~3.json

--- a/tools/run-nrtest.cmd
+++ b/tools/run-nrtest.cmd
@@ -7,24 +7,39 @@
 ::          US EPA - ORD/NRMRL
 ::
 ::  Arguments:
-::    1 - nrtest script path
-::    2 - test suite path
-::    3 - version/build identifier
+::    1 - version/build identifier
+::    2 - (test suite path)
 ::
 
 @echo off
 setlocal
 
-set NRTEST_SCRIPT_PATH=%~1
-set TEST_SUITE_PATH=%~2
+
+:: CHANGE THIS VARIABLES TO UPDATE BENCHMARK
+set BENCHMARK_VER=520dev5
+
+
+:: Determine location of python Scripts folder
+FOR /F "tokens=*" %%G IN ('where python') DO (
+  set PYTHON_DIR=%%~dpG
+)
+set "NRTEST_SCRIPT_PATH=%PYTHON_DIR%Scripts"
+
+:: Check existence and apply default arguments
+IF NOT [%1]==[] ( set "SUT_VER=%~1"
+) ELSE ( set "SUT_VER=vXXX" )
+
+IF NOT [%2]==[] ( set "TEST_SUITE_PATH=%~2"
+) ELSE ( set "TEST_SUITE_PATH=nrtestsuite" )
+
 
 set NRTEST_EXECUTE_CMD=python %NRTEST_SCRIPT_PATH%\nrtest execute
-set TEST_APP_PATH=apps\swmm-%3.json
+set TEST_APP_PATH=apps\swmm-%SUT_VER%.json
 set TESTS=tests\examples tests\extran tests\routing tests\user
-set TEST_OUTPUT_PATH=benchmark\swmm-%3
+set TEST_OUTPUT_PATH=benchmark\swmm-%SUT_VER%
 
 set NRTEST_COMPARE_CMD=python %NRTEST_SCRIPT_PATH%\nrtest compare
-set REF_OUTPUT_PATH=benchmark\swmm-520dev5
+set REF_OUTPUT_PATH=benchmark\swmm-%BENCHMARK_VER%
 set RTOL_VALUE=0.01
 set ATOL_VALUE=0.00
 


### PR DESCRIPTION
This PR simplifies the usage `before-test.cmd` and `run-nrtest.cmd` by introducing default arguments. The scripts can be called with no arguments and the tests will run.

Addresses Issue #224