### PR TITLE
Add search for SUT exe location

### DIFF
--- a/tools/before-test.cmd
+++ b/tools/before-test.cmd
@@ -30,7 +30,7 @@ set "SCRIPT_HOME=%~dp0"
 set "EXE_HOME=Release"
 
 :: Determine SUT executable path
-:: TODO: This fails when there is more than one cmake buildprod folder
+:: TODO: This may fail when there is more than one cmake buildprod folder
 for /d /r "%SCRIPT_HOME%..\" %%a in (*) do if /i "%%~nxa"=="bin" set "BUILD_HOME=%%a"
 set SUT_PATH=%BUILD_HOME%\%EXE_HOME%
 

--- a/tools/before-test.cmd
+++ b/tools/before-test.cmd
@@ -30,6 +30,7 @@ set "SCRIPT_HOME=%~dp0"
 set "EXE_HOME=Release"
 
 :: Determine SUT executable path
+:: TODO: This fails when there is more than one cmake buildprod folder
 for /d /r "%SCRIPT_HOME%..\" %%a in (*) do if /i "%%~nxa"=="bin" set "BUILD_HOME=%%a"
 set SUT_PATH=%BUILD_HOME%\%EXE_HOME%
 

--- a/tools/before-test.cmd
+++ b/tools/before-test.cmd
@@ -27,11 +27,11 @@ set BENCHMARK_VER=520dev5
 
 
 set "SCRIPT_HOME=%~dp0"
-set "EXE_HOME=buildprod\bin\Release"
+set "EXE_HOME=Release"
 
 :: Determine SUT executable path
-for %%a in ("%SCRIPT_HOME:~0,-1%") do set "SUT_PATH=%%~dpa"
-set SUT_PATH=%SUT_PATH%%EXE_HOME%
+for /d /r "%SCRIPT_HOME%..\" %%a in (*) do if /i "%%~nxa"=="bin" set "BUILD_HOME=%%a"
+set SUT_PATH=%BUILD_HOME%\%EXE_HOME%
 
 :: Check existence and apply default arguments
 IF NOT [%1]==[] ( set "SUT_VER=%~1"


### PR DESCRIPTION
`before-test.cmd` searches `PROJECT_HOME` and determines the path to the SUT executable automatically. 

Addresses Issue #224 