### PR TITLE
Add support for multiple-infiltration algorithms 

### DIFF
--- a/.github/REGRESSION_TESTING.md
+++ b/.github/REGRESSION_TESTING.md
@@ -97,7 +97,7 @@ To add a new test the [REPORTS] section of the input file should be configured
 to write all results out to the binary file. A json file also needs to be 
 created that describes how to execute the test, what files are needed, what 
 files get generated, what comparison routines to use, and meta-data describing 
-the test. The format and data found in the json files is resonably well 
+the test. The format and data found in the json files is reasonably well 
 described in the nrtest documentation. The input file, any auxiliary file need 
 to run the test, and the json file describing the test should be added to the 
 swmm-tests folder found in the swmm-example-networks repo. Finally, the test 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Programming Language and released in the Public Domain.
 
 Everyone is welcome to contribute to this project.
 
-See [CONTRIBUTING.md](https://github.com/OpenWaterAnalytics/Stormwater-Management-Model/blob/develop/.github/CONTRIBUTING.md) for insructions on setting your development environment.
+See [CONTRIBUTING.md](https://github.com/OpenWaterAnalytics/Stormwater-Management-Model/blob/develop/.github/CONTRIBUTING.md) for instructions on setting your development environment.
 
 # Regression Testing
 

--- a/src/consts.h
+++ b/src/consts.h
@@ -15,11 +15,11 @@
 // General Constants
 //------------------
 
-// Update VERSION and SEMVERSION Simultaneously 
-#define   VERSION            52000          // Eventually will be deprecated. 
+// Update VERSION and SEMVERSION Simultaneously
+#define   VERSION            52000          // Eventually will be deprecated.
 #define   SEMVERSION_MAJOR   "5"            // Major Semantic Version
 #define   SEMVERSION_MINOR   "2"            // Minor Semantic Version
-#define   SEMVERSION_PATCH   "0.dev6"      // Patch Semantic Version
+#define   SEMVERSION_PATCH   "0.dev5"      // Patch Semantic Version
 #define   SEMVERSION_LEN     20             // Version String Len
 
 #define   MAGICNUMBER        516114522
@@ -99,5 +99,5 @@
 
 //---------------------------
 // Token separator characters
-//--------------------------- 
-#define   SEPSTR    " \t\n\r" 
+//---------------------------
+#define   SEPSTR    " \t\n\r"

--- a/src/consts.h
+++ b/src/consts.h
@@ -19,7 +19,7 @@
 #define   VERSION            52000          // Eventually will be deprecated. 
 #define   SEMVERSION_MAJOR   "5"            // Major Semantic Version
 #define   SEMVERSION_MINOR   "2"            // Minor Semantic Version
-#define   SEMVERSION_PATCH   "0.dev5"      // Patch Semantic Version
+#define   SEMVERSION_PATCH   "0.dev6"      // Patch Semantic Version
 #define   SEMVERSION_LEN     20             // Version String Len
 
 #define   MAGICNUMBER        516114522
@@ -42,6 +42,7 @@
 #define   GRAVITY            32.2           // accel. of gravity in US units
 #define   SI_GRAVITY         9.81           // accel of gravity in SI units
 #define   MAXFILESIZE        2147483647L    // largest file size in bytes
+#define   MULTI_INFIL        1              // multi infiltration types allowed
 
 //-----------------------------
 // Units factor in Manning Eqn.

--- a/src/hotstart.c
+++ b/src/hotstart.c
@@ -378,7 +378,7 @@ void  saveRunoff(void)
 
         // Infiltration state (max. of 6 elements)
         for (j=0; j<sizeX; j++) x[j] = 0.0;
-        infil_getState(i, InfilModel, x);
+        infil_getState(i, Subcatch[i].infil_type, x);
         fwrite(x, sizeof(double), 6, f);
 
         // Groundwater state (4 elements)
@@ -447,7 +447,7 @@ void  readRunoff()
 
         // Infiltration state (max. of 6 elements)
         for (j=0; j<6; j++) if ( !readDouble(&x[j], f) ) return;
-        infil_setState(i, InfilModel, x);
+        infil_setState(i, Subcatch[i].infil_type, x);
 
         // Groundwater state (4 elements)
         if ( Subcatch[i].groundwater != NULL )

--- a/src/hotstart.c
+++ b/src/hotstart.c
@@ -378,7 +378,7 @@ void  saveRunoff(void)
 
         // Infiltration state (max. of 6 elements)
         for (j=0; j<sizeX; j++) x[j] = 0.0;
-        infil_getState(i, Subcatch[i].infil_type, x);
+        infil_getState(i, Subcatch[i].infilModel, x);
         fwrite(x, sizeof(double), 6, f);
 
         // Groundwater state (4 elements)
@@ -447,7 +447,7 @@ void  readRunoff()
 
         // Infiltration state (max. of 6 elements)
         for (j=0; j<6; j++) if ( !readDouble(&x[j], f) ) return;
-        infil_setState(i, Subcatch[i].infil_type, x);
+        infil_setState(i, Subcatch[i].infilModel, x);
 
         // Groundwater state (4 elements)
         if ( Subcatch[i].groundwater != NULL )

--- a/src/infil.c
+++ b/src/infil.c
@@ -181,20 +181,20 @@ int infil_readParams(int m, char* tok[], int ntoks)
     if ( m < 0 ) m = InfilModel; 
 
     // --- number of input tokens depends on infiltration model m
-    if      ( m == HORTON )         n = 5;
+    if      ( m == HORTON )         n = 5; 
     else if ( m == MOD_HORTON )     n = 5;
     else if ( m == GREEN_AMPT )     n = 4;
     else if ( m == MOD_GREEN_AMPT ) n = 4;
     else if ( m == CURVE_NUMBER )   n = 4;
-    else return 0;
+    else return 0; 
 
     if ( ntoks < n ) return error_setInpError(ERR_ITEMS, "");
-
+   
     // --- parse numerical values from tokens
     for (i = 0; i < 5; i++) x[i] = 0.0;
     for (i = 1; i < n; i++)
     {
-        if ( ! getDouble(tok[i], &x[i-1]) )
+        if (!getDouble(tok[i], &x[i - 1]))
             return error_setInpError(ERR_NUMBER, tok[i]);
     }
 
@@ -235,7 +235,6 @@ void infil_initState(int j, int m)
 //  Purpose: initializes state of infiltration for a subcatchment.
 //
 {
-    m = Subcatch[j].infil_type; // 2016-01-15: CHANGE PASS-BY-VALUE, m
     switch (m)
     {
       case HORTON:
@@ -257,7 +256,6 @@ void infil_getState(int j, int m, double x[])
 //  Purpose: retrieves the current infiltration state for a subcatchment.
 //
 {
-    m = Subcatch[j].infil_type; // 2016-01-15: CHANGE PASS-BY-VALUE, m
     switch (m)
     {
       case HORTON:
@@ -279,7 +277,6 @@ void infil_setState(int j, int m, double x[])
 //  Purpose: sets the current infiltration state for a subcatchment.
 //
 {
-    m = Subcatch[j].infil_type; // 2016-01-15: CHANGE PASS-BY-VALUE, m
     switch (m)
     {
       case HORTON:
@@ -334,7 +331,6 @@ double infil_getInfil(int j, int m, double tstep, double rainfall,
 //  Purpose: computes infiltration rate depending on infiltration method.
 //
 {
-    m = Subcatch[j].infil_type; // 2016-01-15: CHANGE PASS-BY-VALUE, m
     switch (m)
     {
       case HORTON:

--- a/src/infil.c
+++ b/src/infil.c
@@ -105,36 +105,17 @@ void infil_create(int subcatchCount, int model)
 //
 {
 
-     // Allocate all 3 kinds of Infiltration data structures, because each
-     // subcatch[j] could be of any type. Doing this uses 3X the RAM: but the
-     // waste is only (2 X subcatchCount X 72 bytes) total.
+    // Allocate each (3) infiltration data structure. This wastes 
+	// at most (2 X subcatchCount X 72 bytes) of RAM. 
     HortInfil = (THorton *) calloc(subcatchCount, sizeof(THorton));
     if ( HortInfil == NULL ) ErrorCode = ERR_MEMORY;
     GAInfil = (TGrnAmpt *)calloc(subcatchCount, sizeof(TGrnAmpt));
     if (GAInfil == NULL) ErrorCode = ERR_MEMORY;
     CNInfil = (TCurveNum *)calloc(subcatchCount, sizeof(TCurveNum));
     if (CNInfil == NULL) ErrorCode = ERR_MEMORY;
-    return;
 
-    switch (model)
-    {
-    case HORTON:
-    case MOD_HORTON:
-        HortInfil = (THorton *) calloc(subcatchCount, sizeof(THorton));
-        if ( HortInfil == NULL ) ErrorCode = ERR_MEMORY;
-        break;
-    case GREEN_AMPT:
-    case MOD_GREEN_AMPT:
-        GAInfil = (TGrnAmpt *) calloc(subcatchCount, sizeof(TGrnAmpt));
-        if ( GAInfil == NULL ) ErrorCode = ERR_MEMORY;
-        break;
-    case CURVE_NUMBER:
-        CNInfil = (TCurveNum *) calloc(subcatchCount, sizeof(TCurveNum));
-        if ( CNInfil == NULL ) ErrorCode = ERR_MEMORY;
-        break;
-    default: ErrorCode = ERR_MEMORY;
-    }
-    InfilFactor = 1.0;                                                         //(5.1.013)
+	InfilFactor = 1.0;    //(5.1.013)
+    return;
 }
 
 //=============================================================================

--- a/src/infil.c
+++ b/src/infil.c
@@ -172,9 +172,17 @@ int infil_readParams(int m, char* tok[], int ntoks)
     if ( j < 0 ) return error_setInpError(ERR_NAME, tok[0]);
 
     // --- check for valid infiltration model keyword, or use default InfilModel
-    int last_tok_ix = sizeof tok / sizeof *tok - 1;
+    int last_tok_ix = 0;
+    for (i = 0; tok[i] != '\0'; i++) { 
+		last_tok_ix = i;
+    }
     m = findmatch(tok[last_tok_ix], InfilModelWords);
-    if ( m < 0 ) m = InfilModel; // return error_setInpError(ERR_KEYWORD, tok[6]);
+    if ( m < 0 ) m = InfilModel; 
+
+    printf("\nlast tok is %s of %d\n", tok[last_tok_ix], ntoks);
+    for (i = 0; tok[i] != '\0'; i++) {    
+        printf("%s, ", tok[i]);
+    }
 
     // --- number of input tokens depends on infiltration model m
     if      ( m == HORTON )         n = 5;
@@ -183,7 +191,21 @@ int infil_readParams(int m, char* tok[], int ntoks)
     else if ( m == MOD_GREEN_AMPT ) n = 4;
     else if ( m == CURVE_NUMBER )   n = 4;
     else return 0;
+    printf("\ninfiltration model is ");
+	if (m == HORTON)
+        fprintf(stderr, "HORTON");
+    else if (m == MOD_HORTON)
+        fprintf(stderr, "MOD_HORTON");
+    else if (m == GREEN_AMPT)
+        fprintf(stderr, "GREEN_AMPT");
+    else if (m == MOD_GREEN_AMPT)
+        fprintf(stderr, "MOD_GREEN_AMPT");
+    else if (m == CURVE_NUMBER)
+        fprintf(stderr, "CURVE_NUMBER");
+    else
+        return 0;
     if ( ntoks < n ) return error_setInpError(ERR_ITEMS, "");
+    fprintf(stderr, "\n");
 
     // --- parse numerical values from tokens
     for (i = 0; i < 5; i++) x[i] = 0.0;

--- a/src/infil.c
+++ b/src/infil.c
@@ -165,14 +165,15 @@ int infil_readParams(int m, char* tok[], int ntoks)
 //     subcatch  p1  p2 ...
 {
     int   i, j, n, status;
-    double x[6];
+    double x[5];
 
     // --- check that subcatchment exists
     j = project_findObject(SUBCATCH, tok[0]);
     if ( j < 0 ) return error_setInpError(ERR_NAME, tok[0]);
 
     // --- check for valid infiltration model keyword, or use default InfilModel
-    m = findmatch(tok[6], InfilModelWords);
+    int last_tok_ix = sizeof tok / sizeof *tok - 1;
+    m = findmatch(tok[last_tok_ix], InfilModelWords);
     if ( m < 0 ) m = InfilModel; // return error_setInpError(ERR_KEYWORD, tok[6]);
 
     // --- number of input tokens depends on infiltration model m

--- a/src/infil.c
+++ b/src/infil.c
@@ -205,9 +205,9 @@ int infil_readParams(int m, char* tok[], int ntoks)
             return error_setInpError(ERR_NUMBER, tok[n]);
     }
 
-    // --- assign parameter values to infil, infil_type object
+    // --- assign parameter values to infil, infilModel object
     Subcatch[j].infil = j;
-    Subcatch[j].infil_type = m;
+    Subcatch[j].infilModel = m;
     switch (m)
     {
       case HORTON:

--- a/src/infil.c
+++ b/src/infil.c
@@ -171,18 +171,14 @@ int infil_readParams(int m, char* tok[], int ntoks)
     j = project_findObject(SUBCATCH, tok[0]);
     if ( j < 0 ) return error_setInpError(ERR_NAME, tok[0]);
 
-    // --- check for valid infiltration model keyword, or use default InfilModel
-    int last_tok_ix = 0;
+    // --- check for valid infiltration model keyword in last tok, 
+	// --- use default InfilModel if no valid InfilModelWord found
+    int ixLastTok= 0;
     for (i = 0; tok[i] != '\0'; i++) { 
-		last_tok_ix = i;
+		ixLastTok = i;
     }
-    m = findmatch(tok[last_tok_ix], InfilModelWords);
+    m = findmatch(tok[ixLastTok], InfilModelWords);
     if ( m < 0 ) m = InfilModel; 
-
-    printf("\nlast tok is %s of %d\n", tok[last_tok_ix], ntoks);
-    for (i = 0; tok[i] != '\0'; i++) {    
-        printf("%s, ", tok[i]);
-    }
 
     // --- number of input tokens depends on infiltration model m
     if      ( m == HORTON )         n = 5;
@@ -191,21 +187,8 @@ int infil_readParams(int m, char* tok[], int ntoks)
     else if ( m == MOD_GREEN_AMPT ) n = 4;
     else if ( m == CURVE_NUMBER )   n = 4;
     else return 0;
-    printf("\ninfiltration model is ");
-	if (m == HORTON)
-        fprintf(stderr, "HORTON");
-    else if (m == MOD_HORTON)
-        fprintf(stderr, "MOD_HORTON");
-    else if (m == GREEN_AMPT)
-        fprintf(stderr, "GREEN_AMPT");
-    else if (m == MOD_GREEN_AMPT)
-        fprintf(stderr, "MOD_GREEN_AMPT");
-    else if (m == CURVE_NUMBER)
-        fprintf(stderr, "CURVE_NUMBER");
-    else
-        return 0;
+
     if ( ntoks < n ) return error_setInpError(ERR_ITEMS, "");
-    fprintf(stderr, "\n");
 
     // --- parse numerical values from tokens
     for (i = 0; i < 5; i++) x[i] = 0.0;

--- a/src/infil.h
+++ b/src/infil.h
@@ -103,6 +103,7 @@ void    infil_setInfilFactor(int j);                                           /
 double  infil_getInfil(int area, int model, double tstep, double rainfall,
         double runon, double depth);
 
+void    grnampt_getParams(int j, double p[]);                                  //(5.1.013)
 int     grnampt_setParams(TGrnAmpt *infil, double p[]);
 void    grnampt_initState(TGrnAmpt *infil);
 double  grnampt_getInfil(TGrnAmpt *infil, double tstep, double irate,

--- a/src/lid.c
+++ b/src/lid.c
@@ -1717,7 +1717,7 @@ void findNativeInfil(int j, double tStep)
     //... otherwise find infil. rate for the subcatchment's rainfall + runon
     else
     {
-        NativeInfil = infil_getInfil(j, InfilModel, tStep,
+        NativeInfil = infil_getInfil(j, Subcatch[j].infil_type, tStep,
                                      Subcatch[j].rainfall,
                                      Subcatch[j].runon,
                                      getSurfaceDepth(j));                      //(5.1.008)

--- a/src/lid.c
+++ b/src/lid.c
@@ -1150,7 +1150,7 @@ void validateLidGroup(int j)
         {
             if ( InfilModel == GREEN_AMPT || InfilModel == MOD_GREEN_AMPT )
             {
-		grnampt_getParams(j, p);
+                grnampt_getParams(j, p);
                 if ( grnampt_setParams(&(lidUnit->soilInfil), p) == FALSE )
                 {
                     strcpy(Msg, LidProcs[k].ID);

--- a/src/lid.c
+++ b/src/lid.c
@@ -1717,7 +1717,7 @@ void findNativeInfil(int j, double tStep)
     //... otherwise find infil. rate for the subcatchment's rainfall + runon
     else
     {
-        NativeInfil = infil_getInfil(j, Subcatch[j].infil_type, tStep,
+        NativeInfil = infil_getInfil(j, Subcatch[j].infilModel, tStep,
                                      Subcatch[j].rainfall,
                                      Subcatch[j].runon,
                                      getSurfaceDepth(j));                      //(5.1.008)

--- a/src/lid.c
+++ b/src/lid.c
@@ -1150,9 +1150,7 @@ void validateLidGroup(int j)
         {
             if ( InfilModel == GREEN_AMPT || InfilModel == MOD_GREEN_AMPT )
             {
-                p[0] = GAInfil[j].S * UCF(RAINDEPTH);
-                p[1] = GAInfil[j].Ks * UCF(RAINFALL);
-                p[2] = GAInfil[j].IMDmax;
+		grnampt_getParams(j, p);
                 if ( grnampt_setParams(&(lidUnit->soilInfil), p) == FALSE )
                 {
                     strcpy(Msg, LidProcs[k].ID);

--- a/src/objects.h
+++ b/src/objects.h
@@ -399,7 +399,7 @@ typedef struct
    double*       concPonded;      // ponded surface water quality concentration (mass/L)
    double*       totalLoad;       // total washoff load (lbs or kg)
    double*       surfaceBuildup;  // surface buildup (mass)
-   int           infil_type;      // infiltration model code 
+   int           infilModel;      // infiltration model code
 }  TSubcatch;
 
 //-----------------------

--- a/src/objects.h
+++ b/src/objects.h
@@ -399,6 +399,7 @@ typedef struct
    double*       concPonded;      // ponded surface water quality concentration (mass/L)
    double*       totalLoad;       // total washoff load (lbs or kg)
    double*       surfaceBuildup;  // surface buildup (mass)
+   int           infil_type;      // infiltration model code 
 }  TSubcatch;
 
 //-----------------------

--- a/src/project.c
+++ b/src/project.c
@@ -1099,7 +1099,7 @@ void createObjects()
         Subcatch[j].gwDeepFlowExpr = NULL;
         Subcatch[j].snowpack    = NULL;
         Subcatch[j].lidArea     = 0.0;
-        Subcatch[j].infil_type = InfilModel;     // 2016-01-15: default all subcatch infil_type to global INFILTRATION specified in mode
+        Subcatch[j].infilModel = InfilModel;
         for (k = 0; k < Nobjects[POLLUT]; k++)
         {
             Subcatch[j].initBuildup[k] = 0.0;

--- a/src/project.c
+++ b/src/project.c
@@ -1099,6 +1099,7 @@ void createObjects()
         Subcatch[j].gwDeepFlowExpr = NULL;
         Subcatch[j].snowpack    = NULL;
         Subcatch[j].lidArea     = 0.0;
+        Subcatch[j].infil_type = InfilModel;     // 2016-01-15: default all subcatch infil_type to global INFILTRATION specified in mode
         for (k = 0; k < Nobjects[POLLUT]; k++)
         {
             Subcatch[j].initBuildup[k] = 0.0;
@@ -1300,15 +1301,3 @@ void deleteHashTables()
 }
 
 //=============================================================================
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/subcatch.c
+++ b/src/subcatch.c
@@ -190,7 +190,7 @@ int  subcatch_readParams(int j, char* tok[], int ntoks)
     Subcatch[j].nPervPattern  = -1;                                            //(5.1.013
     Subcatch[j].dStorePattern = -1;                                            //
     Subcatch[j].infilPattern  = -1;                                            //
-    Subcatch[j].infil_type    = -1;                                            // 2019/05/22
+    Subcatch[j].infilModel    = -1;                                            // 2019/05/22
 
     // --- create the snow pack object if it hasn't already been created
     if ( x[8] >= 0 )
@@ -448,7 +448,7 @@ void  subcatch_initState(int j)
     Subcatch[j].infilLoss = 0.0;
 
     // --- initialize state of infiltration, groundwater, & snow pack objects
-    if ( Subcatch[j].infil == j )  infil_initState(j, Subcatch[j].infil_type);
+    if ( Subcatch[j].infil == j )  infil_initState(j, Subcatch[j].infilModel);
     if ( Subcatch[j].groundwater ) gwater_initState(j);
     if ( Subcatch[j].snowpack )    snow_initSnowpack(j);
 
@@ -1028,7 +1028,7 @@ double getSubareaInfil(int j, TSubarea* subarea, double precip, double tStep)
     double infil = 0.0;                     // actual infiltration rate (ft/sec)
 
     // --- compute infiltration rate 
-    infil = infil_getInfil(j, Subcatch[j].infil_type, tStep, precip,
+    infil = infil_getInfil(j, Subcatch[j].infilModel, tStep, precip,
                            subarea->inflow, subarea->depth);
 
     // --- limit infiltration rate by available void space in unsaturated

--- a/src/subcatch.c
+++ b/src/subcatch.c
@@ -448,7 +448,7 @@ void  subcatch_initState(int j)
     Subcatch[j].infilLoss = 0.0;
 
     // --- initialize state of infiltration, groundwater, & snow pack objects
-    if ( Subcatch[j].infil == j )  infil_initState(j, InfilModel);
+    if ( Subcatch[j].infil == j )  infil_initState(j, Subcatch[j].infil_type);
     if ( Subcatch[j].groundwater ) gwater_initState(j);
     if ( Subcatch[j].snowpack )    snow_initSnowpack(j);
 
@@ -1028,7 +1028,7 @@ double getSubareaInfil(int j, TSubarea* subarea, double precip, double tStep)
     double infil = 0.0;                     // actual infiltration rate (ft/sec)
 
     // --- compute infiltration rate 
-    infil = infil_getInfil(j, InfilModel, tStep, precip,
+    infil = infil_getInfil(j, Subcatch[j].infil_type, tStep, precip,
                            subarea->inflow, subarea->depth);
 
     // --- limit infiltration rate by available void space in unsaturated

--- a/src/subcatch.c
+++ b/src/subcatch.c
@@ -190,6 +190,7 @@ int  subcatch_readParams(int j, char* tok[], int ntoks)
     Subcatch[j].nPervPattern  = -1;                                            //(5.1.013
     Subcatch[j].dStorePattern = -1;                                            //
     Subcatch[j].infilPattern  = -1;                                            //
+    Subcatch[j].infil_type    = -1;                                            // 2019/05/22
 
     // --- create the snow pack object if it hasn't already been created
     if ( x[8] >= 0 )

--- a/tools/run-nrtest.cmd
+++ b/tools/run-nrtest.cmd
@@ -12,7 +12,7 @@
 ::    3 - (test suite path)
 ::
 
-@echo off
+REM @echo off
 setlocal
 
 
@@ -27,10 +27,10 @@ IF [%3]==[] ( set "TEST_SUITE_PATH=nrtestsuite"
 ) ELSE ( set "TEST_SUITE_PATH=%~3" )
 
 
-:: determine location of python Scripts folder
-FOR /F "tokens=*" %%G IN ('where python') DO (
-  set PYTHON_DIR=%%~dpG
-)
+:: determine location of python Scripts folder, first result on PATH
+set "PYTHON_DIR="
+FOR /F "tokens=*" %%G IN ('where python') DO if not defined PYTHON_DIR set PYTHON_DIR=%%~dpG
+
 set "NRTEST_SCRIPT_PATH=%PYTHON_DIR%Scripts"
 
 


### PR DESCRIPTION
Adds an `infil_type` parameter to each Subcatch object where subcat-specific infiltration algorithms can be stored. Non-default infiltration algorithms can be configured by including one of the following keywords to the end of any row in the [INFILTRATION] section:
- **HORTON**  - Horton infiltration
- **MOD_HORTON** - Modified Horton infiltration
- **GREEN_AMPT** - Green-Ampt infiltration
- **MOD_GREEN_AMPT** - Modified Green-Ampt infiltration
- **CURVE_NUMBER** - SCS Curve Number infiltration

For example, in a model that uses Horton infiltration by default, subcatchment `C` can use Green-Ampt infiltration by configuring the [INFILTRATION] section like this:
```
[INFILTRATION]
;;Subcatchment   MaxRate    MinRate    Decay      DryTime    MaxInfil    InfiltrationType
;;-------------- ---------- ---------- ---------- ---------- ----------  -----------------
A                3          0.5        4          7          0           
B                3          0.5        4          7          0           
C                0.5        0.1        0                                 GREEN_AMPT
```
Proposed solution to resolve #234. 