### PR TITLE
Create new PR to identify appveyor pr fail cause

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,9 +12,9 @@ Abhiram Mullapudi <abhiramm@umich.edu>
 Jennifer Wu <jennifer.wu@live.com> (EmNet)
 Hsi-Nien Tan <hsi-nien.tan@mail.hyd.ncku.edu.tw>
 
-# Author contributions are made under the MIT License,
-# unless denoted by (public domain), which indicates that contributions
-# were made in the public domain.
+Author contributions are made under the MIT License,
+unless denoted by (public domain), which indicates that contributions
+were made in the public domain.
 
 
 


### PR DESCRIPTION
Previously builds were failing due to clahub. Clahub is now turned off, trying to merge a new PR to refresh the PR fail build message on develop branch. 