### PR TITLE
Refactor SMO_free in swmm-output to be compatible with swmm-python

### DIFF
--- a/src/outfile/include/swmm_output.h
+++ b/src/outfile/include/swmm_output.h
@@ -66,7 +66,7 @@ int EXPORT_OUT_API SMO_getLinkResult(SMO_Handle p_handle, int timeIndex,
 int EXPORT_OUT_API SMO_getSystemResult(SMO_Handle p_handle, int timeIndex,
 	int dummyIndex, float** outValueArray, int* arrayLength);
 
-void EXPORT_OUT_API SMO_free(void** array);
+void EXPORT_OUT_API SMO_freeMemory(void *array);
 void EXPORT_OUT_API SMO_clearError(SMO_Handle p_handle_in);
 int EXPORT_OUT_API SMO_checkError(SMO_Handle p_handle_in, char** msg_buffer);
 

--- a/src/outfile/swmm_output.c
+++ b/src/outfile/swmm_output.c
@@ -847,15 +847,12 @@ int EXPORT_OUT_API SMO_getSystemResult(SMO_Handle p_handle, int periodIndex,
     return set_error(p_data->error_handle, errorcode);
 }
 
-void EXPORT_OUT_API SMO_free(void** array)
+void EXPORT_OUT_API SMO_freeMemory(void *array)
 //
 //  Purpose: Frees memory allocated by API calls
 //
 {
-    if (array != NULL) {
-        free(*array);
-        *array = NULL;
-    }
+    free(array);
 }
 
 void EXPORT_OUT_API SMO_clearError(SMO_Handle p_handle)


### PR DESCRIPTION
Update SMO_free function(**) in swmm-output library and refactor to SMO_freeMemory(*) to be compatible with swmm-python. 