### PR TITLE
Updating LICENSE file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,10 +17,10 @@ Adam Erispaha <aerispaha@gmail.com>
 Sam Hatchett <samhatchett@gmail.com>
 Gonzalo Peña-Castellanos <goanpeca@gmail.com>
 Abhiram Mullapudi <abhiramm@umich.edu>
-Jennifer Wu <jennifer.wu@xyleminc.com>
+Jennifer Wu <wuu.jennifer@gmail.com >
 Dominik Leutnant <leutnant@fh-muenster.de>
 Xu Xi <12907470@qq.com>
-Caleb Buahin <caleb.buahin@xyleminc.com>
+Caleb Buahin <caleb.buahin@gmail.com>
 Hsi-Nien Tan <hsi-nien.tan@vumc.org>
 Mingda Zhang <mingda_zhang@163.com>
 Laurent Courty <lrntct@gmail.com>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,16 @@ set(CMAKE_INSTALL_OPENMP_LIBRARIES TRUE)
 include(InstallRequiredSystemLibraries)
 
 
+# Create install target for License and Authors files
+install(
+    FILES
+        "LICENSE"
+        "AUTHORS"
+    DESTINATION
+        "."
+)
+
+
 # Configure CPack driven installer package
 set(CPACK_GENERATOR "ZIP;TGZ")
 set(CPACK_PACKAGE_VENDOR "US_EPA")

--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,34 @@
+This project contains original material released as part of USEPA SWMM v5.1.13.
+Original material residing in the public domain is unclaimable.
+
+This project also contains new material prepared by the United States
+Government for which domestic copyright protection is not available under 17
+USC § 105.
+
+
+Public Domain
+
+Material original to USEPA SWMM v5.1.13 No Copyright Restrictions
+
+Output library, shared objects, CLI, build and test systems No Copyright
+Restrictions 2020 U.S. Federal Government
+
+===============================================================================
+
+This project contains material from https://github.com/OpenWaterAnalytics/
+Stormwater-Management-Model. All material created by the AUTHORS is released
+under the MIT License.
+
+OWA SWMM may also includes third-party software libraries which have separate
+licensing policies.
+
+
+
 MIT License
 
-Contains public domain works.  Other works copyright the AUTHORS
+Copyright (c) 2020 see AUTHORS, excluding material in the public
+domain.
 
-Copyright (c) 2016 (see AUTHORS.txt).
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -21,3 +47,9 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+
+Third-Party Libraries
+
+OpenMP


### PR DESCRIPTION
The LICENSE file has been updated to do the following: 
 - Properly identify those portions of the material that are claimable and those portions that are unclaimable
 - Identify portions of new materials that reside in the public domain because they were prepared by US Gov employees
 - Update year on notice of copyright
 - Add notice that Licenses associated with third party libraries may apply  