### PR TITLE
Make OpenMP optional for wheel build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,9 @@ endif()
 
 
 # Create install rules for vcruntime.dll, msvcp.dll, vcomp.dll etc.
-set(CMAKE_INSTALL_OPENMP_LIBRARIES TRUE)
+if(OpenMP_FOUND)
+	set(CMAKE_INSTALL_OPENMP_LIBRARIES TRUE)
+endif()
 include(InstallRequiredSystemLibraries)
 
 

--- a/src/solver/CMakeLists.txt
+++ b/src/solver/CMakeLists.txt
@@ -124,7 +124,7 @@ install(
 
 # TODO: Figure out why this doesn't work for package target
 # When building on MacOS relocate libomp to install package
-if(APPLE)
+if(APPLE AND OpenMP_FOUND)
     get_filename_component(EXTERN_LIB_PATH ${OpenMP_libomp_LIBRARY} REALPATH)
 
     install(


### PR DESCRIPTION
This is a small PR that carries minor changes to cmake find_openmp so OpenMP library is optional for wheel build. 