### PR TITLE
Making OpenMP optional

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -81,8 +81,13 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
+
+      - name: Clone ci-tools repo
+        uses: actions/checkout@v2
         with:
-          submodules: recursive
+          repository: OpenWaterAnalytics/ci-tools
+          ref: master
+          path: ci-tools
 
       - name: Setup python
         uses: actions/setup-python@v2

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Before reg test
         run: |
-          ./before-nrtest.${{ matrix.script_extension }}
+          ./before-nrtest.${{ matrix.script_extension }} v1.0.3-dev
 
       - name: Run reg test
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -30,6 +30,7 @@ jobs:
         requirements: [requirements-swmm.txt]
         include:
           - os: windows-2016
+            sys_pkgs: choco install boost-msvc-14.1
             generator: Visual Studio 15 2017 Win64
             experimental: true
             script_extension: cmd
@@ -40,7 +41,9 @@ jobs:
               run:
                 shell: cmd
                 working-directory: ./ci-tools/windows
+
           - os: ubuntu-16.04
+            sys_pkgs: sudo apt install libboost-dev libboost-all-dev
             generator: "Unix Makefiles"
             experimental: true
             script_extension: sh
@@ -51,7 +54,9 @@ jobs:
               run:
                 shell: bash
                 working-directory: ./ci-tools/linux
-          - os: macos-latest
+
+          - os: macos-10.15
+            sys_pkgs: brew install libomp boost
             generator: Xcode
             experimental: true
             ci_tools_path: ci-tools/darwin
@@ -99,11 +104,8 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r ${{ matrix.requirements }}
 
-      - name: Install Darwin requirements
-        if: ${{ contains(matrix.os, 'macos') }}
-        run: |
-          brew install libomp
-          brew install boost
+      - name: Install required system packages
+        run: ${{ matrix.sys_pkgs }}
 
       - name: Build and unit test
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2016, ubuntu-16.04, macos-latest]
+        os: [windows-2016, ubuntu-16.04, macos-10.15]
         requirements: [requirements-swmm.txt]
         include:
           - os: windows-2016

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ci-tools"]
-	path = ci-tools
-	url = https://github.com/OpenWaterAnalytics/ci-tools.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CMakeLists.txt - CMake configuration file for swmm-solver
 #
 # Created: July 11, 2019
-# Updated: May 29, 2020
+# Updated: May 19, 2021
 #
 # Author: Michael E. Tryby
 #         US EPA ORD/CESER
@@ -61,14 +61,10 @@ if(BUILD_TESTS)
 endif()
 
 
-# Pass var up the project tree
-if(APPLE)
-    set(EXTERN_LIB_PATH ${EXTERN_LIB_PATH} PARENT_SCOPE)
-endif()
-
-
 # Create install rules for vcruntime.dll, msvcp.dll, vcomp.dll etc.
-set(CMAKE_INSTALL_OPENMP_LIBRARIES TRUE)
+if(OpenMP_FOUND)
+    set(CMAKE_INSTALL_OPENMP_LIBRARIES TRUE)
+endif()
 include(InstallRequiredSystemLibraries)
 
 

--- a/src/solver/CMakeLists.txt
+++ b/src/solver/CMakeLists.txt
@@ -2,14 +2,17 @@
 # CMakeLists.txt - CMake configuration file for swmm-solver/library
 #
 # Created: Jul 11, 2019
-# Updated: Mar  5, 2020
+# Updated: May  19, 2021
 #
 # Author: Michael E. Tryby
 #         US EPA ORD/CESER
 #
 
 
-find_package(OpenMP REQUIRED)
+find_package(OpenMP
+    OPTIONAL_COMPONENTS
+        C
+)
 
 
 # configure file groups
@@ -55,6 +58,9 @@ target_compile_options(swmm5
             "$<$<CONFIG:Release>:/fp:fast>"
             "$<$<CONFIG:Release>:/Zi>"
         ">"
+        $<$<C_COMPILER_ID:AppleClang>:
+            $<$<STREQUAL:"${CMAKE_GENERATOR}","Ninja">:-O3>
+        >
 )
 
 target_link_options(swmm5
@@ -67,7 +73,8 @@ target_link_options(swmm5
 target_link_libraries(swmm5
     PUBLIC
         $<$<NOT:$<BOOL:$<C_COMPILER_ID:MSVC>>>:m>
-        $<$<BOOL:OpenMP_C_FOUND>:OpenMP::OpenMP_C>
+        $<$<BOOL:${OpenMP_C_FOUND}>:OpenMP::OpenMP_C>
+        $<$<BOOL:${OpenMP_AVAILABLE}>:omp>
 )
 
 target_include_directories(swmm5
@@ -100,23 +107,6 @@ install(
     DESTINATION
         "${INCLUDE_DIST}"
 )
-
-
-# TODO: Figure out why this doesn't work for package target
-# When building on MacOS relocate libomp to install package
-if(APPLE)
-    get_filename_component(EXTERN_LIB_PATH ${OpenMP_libomp_LIBRARY} REALPATH)
-
-    install(
-        FILES
-            ${EXTERN_LIB_PATH}
-        DESTINATION
-            ${CMAKE_INSTALL_PREFIX}/extern
-    )
-
-    # Pass the var up the project tree
-    set(EXTERN_LIB_PATH ${EXTERN_LIB_PATH} PARENT_SCOPE)
-endif()
 
 
 # copy swmm5 to build tree for testing


### PR DESCRIPTION
Changes:
This PR makes targeted changes to the build system related to OpenMP for wheel builds on Apple:

- OpenMP library is changed from a required to an optional dependency
- When Ninja generator gets used with Apple Clang the -O3 compiler flag is added

Justification:
Library OpenMP (libomp) is not present on Apple platforms. It can be installed easily enough, however, binary compatibility of the library with Python is required for packaging wheels. Therefore, we need the flexibility to use libomp when it is present on the system, and to build it from scratch when it is not. This PR makes targeted changes to the build system to give us that flexibility. The libomp build actually occurs in swmm-python/swmm-toolkit repository. swmm-solver users not interested in building wheels are unaffected by these changes. 

Lastly, these changes are already present in the dev branch and are being pulled forward to hotfix the wheel build.