### PR TITLE
Fix Output API SMO_getSystemAttribute

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -39,6 +39,11 @@ E: samhatchett@gmail.com
 L: MIT License
 D: Development operations
 
+N: Constantine Karos
+E: ckaros@outlook.com
+L: MIT License
+D: Bug fix, testing
+
 N: Dominik Leutnant
 E: leutnant@fh-muenster.de
 L: MIT License

--- a/src/outfile/include/swmm_output_enums.h
+++ b/src/outfile/include/swmm_output_enums.h
@@ -94,7 +94,7 @@ typedef enum {
     SMO_outfall_flows,          // (flow units),
     SMO_volume_stored,          // (ft3 or m3),
     SMO_evap_rate               // (in/day or mm/day),
-	//p_evap_rate             // (in/day or mm/day)
+	SMO_p_evap_rate             // (in/day or mm/day)
 } SMO_systemAttribute;
 
 

--- a/src/outfile/include/swmm_output_enums.h
+++ b/src/outfile/include/swmm_output_enums.h
@@ -93,8 +93,8 @@ typedef enum {
     SMO_flood_losses,           // (flow units),
     SMO_outfall_flows,          // (flow units),
     SMO_volume_stored,          // (ft3 or m3),
-    SMO_evap_rate               // (in/day or mm/day),
-	SMO_p_evap_rate             // (in/day or mm/day)
+    SMO_evap_rate,              // (in/day or mm/day),
+    SMO_p_evap_rate             // (in/day or mm/day)
 } SMO_systemAttribute;
 
 

--- a/src/outfile/swmm_output.c
+++ b/src/outfile/swmm_output.c
@@ -730,7 +730,7 @@ int EXPORT_OUT_API SMO_getSystemAttribute(SMO_Handle p_handle, int periodIndex,
         // don't need to loop since there's only one system
         temp[0] = getSystemValue(p_data, periodIndex, attr);
 
-        *outValueArray = &temp;
+        *outValueArray = temp;
         *length        = 1;
     }
 


### PR DESCRIPTION
I am a user of the [swmm-python package](https://github.com/OpenWaterAnalytics/swmm-python) and found I was getting the following error when calling the SMO_getSystemAttribute function from python:

```python
>>> from swmm.toolkit import output, shared_enum
>>> _handle = output.init()
>>> output.open(_handle,'tests/Model.out')
>>> output.get_system_attribute(_handle,10,shared_enum.SystemAttribute.RAINFALL)
free(): invalid size
[1]    346884 IOT instruction (core dumped)  python
```

I was able to resolve the issue with a tiny edit to the SMO_getSystemAttribute function. I'm not much of a C-programmer, but the output of that function (**outValueArray) is a double pointer. The current code sets that output as: `*outValueArray = &temp;`. Since temp is already defined as a pointer, to me that logic is creating a triple pointer. By changing the line to: `*outValueArray = temp;`, I fixed my swmm-python error:

```python
>>> from swmm.toolkit import output, shared_enum
>>> _handle=output.init()
>>> output.open(_handle,'tests/Model.out')
>>> output.get_system_attribute(_handle,10,shared_enum.SystemAttribute.RAINFALL)
[0.029999999329447746]
```

This pull request also includes adding the PET term into the output SystemAttribute enum. Not sure what that line was commented out, but maybe we can add it in now since PET is a current system attribute in SWMM 5.1.010 and later?