### PR TITLE
toolkit pollutant setter and getter fixes

### DIFF
--- a/src/solver/include/toolkit.h
+++ b/src/solver/include/toolkit.h
@@ -397,20 +397,21 @@ EXPORT_TOOLKIT int swmm_getNodePollut(int index, SM_NodePollut type, double **po
 EXPORT_TOOLKIT int swmm_setNodePollut(int index, int pollutant_index, double pollutant_value);
 
 /**
- @brief Sets pollutant values for a specified link.
- @param index The index of a link
+ @brief Sets pollutant values for a specified node.
+ @param index The index of a node
  @param pollutant_index Pollutant index to set
  @param pollutant_value Pollutant value to set 
  @return Error code
 */
 
-EXPORT_TOOLKIT int swmm_setLinkPollut(int index, int type, int pollutant_index, double pollutant_value);
+EXPORT_TOOLKIT int swmm_setLinkPollut(int index, SM_LinkPollut type, int pollutant_index, double pollutant_value);
 
 /**
- @brief Get a result value for specified link.
+ @brief Sets pollutant values for a specified link.
  @param index The index of a link
- @param type The property type code (See @ref SM_LinkResult)
- @param[out] result The result of the link's property
+ @param type The property type code (See @ref SM_LinkPollut)
+ @param pollutant_index Pollutant index to set
+ @param pollutant_value Pollutant value to set 
  @return Error code
 */
 EXPORT_TOOLKIT int swmm_getLinkResult(int index, SM_LinkResult type, double *result);

--- a/src/solver/toolkit.c
+++ b/src/solver/toolkit.c
@@ -1872,8 +1872,8 @@ EXPORT_TOOLKIT int swmm_getNodeResult(int index, SM_NodeResult type, double *res
                             + Node[index].invertElev) * UCF(LENGTH); break;
             case SM_LATINFLOW:
                 *result = Node[index].newLatFlow * UCF(FLOW); break;
-	    case SM_HRT:
-		*result = Node[index].hrt; break;
+	        case SM_HRT:
+		        *result = Storage[Node[index].subIndex].hrt; break;
             default: error_code_index = ERR_API_OUTBOUNDS; break;
         }
     }
@@ -2083,7 +2083,7 @@ EXPORT_TOOLKIT int swmm_getLinkPollut(int index, SM_LinkPollut type, double **po
 }
 
 
-EXPORT_TOOLKIT int swmm_setLinkPollut(int index, int type, int pollutant_index, double pollutant_value)
+EXPORT_TOOLKIT int swmm_setLinkPollut(int index, SM_LinkPollut type, int pollutant_index, double pollutant_value)
 ///
 ///  Input: index = Index of the desired Link ID
 /// 	    type = SM_LINKQUAL - Sets link's qual and allows accounting for loss and mixing calculation


### PR DESCRIPTION
This PR address issues noted in discussion of https://github.com/OpenWaterAnalytics/swmm-python/pull/94

- swmm_getNodeResult should return HRT from Storage[] instead of Node[] (which appears to not be used by the model)
- change swmm_setLinkPollut `type` argument to SM_LinkPollut instead of int (addresses #363)
- minor doc string fixes for swmm_setNodePollut and swmm_setLinkPollut