### PR TITLE
Update GitHub actions runners 

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,15 +20,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2016, ubuntu-16.04, macos-10.15]
+        os: [windows-2022, ubuntu-20.04, macos-10.15]
         requirements: [requirements-swmm.txt]
         include:
-          - os: windows-2016
+          - os: windows-2022
             sys_pkgs: choco install boost-msvc-14.1
-            build_unit_test: make.cmd -t -g "Visual Studio 15 2017 Win64"
-            build_reg_test:  make.cmd -g "Visual Studio 15 2017 Win64"
+            build_unit_test: make.cmd -t -g "Visual Studio 17 2022" -A x64
+            build_reg_test: make.cmd -g "Visual Studio 17 2022" -A x64
             before_reg_test: before-nrtest.cmd
-            run_reg_test:    run-nrtests.cmd
+            run_reg_test: run-nrtests.cmd
             build_id: "%GITHUB_RUN_ID%_%GITHUB_RUN_NUMBER%"
             experimental: false
             artifacts_ext: zip
@@ -38,12 +38,12 @@ jobs:
                 shell: cmd
                 working-directory: ./ci-tools/windows
 
-          - os: ubuntu-16.04
+          - os: ubuntu-20.04
             sys_pkgs: sudo apt install libboost-dev libboost-all-dev
-            build_unit_test: make.sh -t -g "Unix Makefiles"
-            build_reg_test:  make.sh -g "Unix Makefiles"
+            build_unit_test: make.sh -s -t -g "Unix Makefiles"
+            build_reg_test: make.sh -s -g "Unix Makefiles"
             before_reg_test: before-nrtest.sh
-            run_reg_test:    run-nrtests.sh
+            run_reg_test: run-nrtests.sh
             build_id: ${GITHUB_RUN_ID}_${GITHUB_RUN_NUMBER}
             experimental: true
             artifacts_ext: tar.gz
@@ -56,9 +56,9 @@ jobs:
           - os: macos-10.15
             sys_pkgs: brew install libomp boost
             build_unit_test: make.zsh -t -g "Xcode"
-            build_reg_test:  make.zsh -g "Xcode"
+            build_reg_test: make.zsh -g "Xcode"
             before_reg_test: before-nrtest.zsh
-            run_reg_test:    run-nrtests.zsh
+            run_reg_test: run-nrtests.zsh
             build_id: ${GITHUB_RUN_ID}_${GITHUB_RUN_NUMBER}
             experimental: true
             artifacts_ext: tar.gz
@@ -79,7 +79,6 @@ jobs:
       PROJECT: swmm
       BUILD_HOME: build
       TEST_HOME: nrtests
-
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -25,8 +25,8 @@ jobs:
         include:
           - os: windows-2022
             sys_pkgs: choco install boost-msvc-14.1
-            build_unit_test: make.cmd -t -g "Visual Studio 17 2022" -A x64
-            build_reg_test: make.cmd -g "Visual Studio 17 2022" -A x64
+            build_unit_test: make.cmd /g "Visual Studio 17 2022" /A "x64" /t
+            build_reg_test: make.cmd /g "Visual Studio 17 2022" /A "x64"
             before_reg_test: before-nrtest.cmd
             run_reg_test: run-nrtests.cmd
             build_id: "%GITHUB_RUN_ID%_%GITHUB_RUN_NUMBER%"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -40,6 +40,7 @@ jobs:
 
           - os: ubuntu-20.04
             sys_pkgs: sudo apt install libboost-dev libboost-all-dev
+            # Statically link libraries with -s switch to address GitHub Ubuntu 20.04 symbol errors (issue #340)
             build_unit_test: make.sh -s -t -g "Unix Makefiles"
             build_reg_test: make.sh -s -g "Unix Makefiles"
             before_reg_test: before-nrtest.sh

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Before reg test
         env:
           NRTESTS_URL: https://github.com/OpenWaterAnalytics/swmm-nrtestsuite
-          BENCHMARK_TAG: v1.0.4-dev
+          BENCHMARK_TAG: v2.0.1
         run: ./${{ matrix.before_reg_test }} ${{ env.BENCHMARK_TAG }}
 
       - name: Run reg test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ set(CONFIG_DIST  "cmake")
 # Define build options
 option(BUILD_TESTS "Build component tests (requires Boost)" OFF)
 option(BUILD_DOCS "Build toolkit docs (requires Doxygen)" OFF)
-
+option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 
 # Add project subdirectories
 if(BUILD_DOCS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,8 @@ set(CONFIG_DIST  "cmake")
 # Define build options
 option(BUILD_TESTS "Build component tests (requires Boost)" OFF)
 option(BUILD_DOCS "Build toolkit docs (requires Doxygen)" OFF)
+
+# Added option to statically link libraries to address GitHub Ubuntu 20.04 symbol errors (issue #340)
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 
 # Add project subdirectories

--- a/src/outfile/CMakeLists.txt
+++ b/src/outfile/CMakeLists.txt
@@ -18,8 +18,7 @@ set(SWMM_OUT_PUBLIC_HEADERS
 
 
 # the binary output file API
-add_library(swmm-output
-    SHARED
+add_library(swmm-output    
         swmm_output.c
         errormanager.c
 )

--- a/src/solver/CMakeLists.txt
+++ b/src/solver/CMakeLists.txt
@@ -38,8 +38,7 @@ if(BUILD_DEF)
         PROPERTIES_HEADER_FILE_ONLY TRUE
     )
 
-    add_library(swmm5
-        SHARED
+    add_library(swmm5        
             ${SWMM_SOURCES}
             ${PROJECT_SOURCE_DIR/bindings/swmm5.def}
             $<TARGET_OBJECTS:shared_objs>
@@ -47,8 +46,7 @@ if(BUILD_DEF)
 
 else()
     # Performs standard library build
-    add_library(swmm5
-        SHARED
+    add_library(swmm5        
             ${SWMM_SOURCES}
             $<TARGET_OBJECTS:shared_objs>
     )


### PR DESCRIPTION
Updates build-test.yml windows to VS 2022 and Ubuntu to 20.04

To solve issues shown in #340, CMakeLists.txt were edited to support [cmake option BUILD_SHARED_LIBS](https://cmake.org/cmake/help/latest/guide/tutorial/Selecting%20Static%20or%20Shared%20Libraries.html). Coupled with [changes to the ci-tools repo](https://github.com/OpenWaterAnalytics/ci-tools/pull/16), this PR will allow developers to optionally use static linking with SWMM libraries.

This update is prompted by discussions in #368
