### PR TITLE
Address system routing and runoff stats bug (#354)

### DIFF
--- a/src/solver/funcs.h
+++ b/src/solver/funcs.h
@@ -270,7 +270,7 @@ void    massbal_addSeepageLoss(int pollut, double seepLoss);
 void    massbal_addToFinalStorage(int pollut, double mass);
 double  massbal_getStepFlowError(void);
 double  massbal_getRunoffError(void);
-double  massbal_getFlowError(void);
+double  massbal_getFlowError(char isFinalStorage); // OWA EDIT - added isFinalStorage param to allow running flow error calcs
 
 //-----------------------------------------------------------------------------
 //   Simulation Statistics Methods


### PR DESCRIPTION
These edits fix #354 and were cherry picked from @jennwuu's fork.

### Changes to massbal_getFlowError 

Essentially this adds a param (isFinalStorage) to massbal_getFlowError to flag whether or not we want end of simulation storage or not. This param gets passed down to massbal_getStorage, which already we parameterized with isFinalStorage.

If isFinalStorage=True, the stored volume in each node is added to the NodeOutflow array that is used compute the flow error for each node in the stats report. If isFinalStorage=False, the stored volume in each node is accumulated and returned only. If massbal_getFlowError called multiple times with isFinalStorage=True, the flow error reported in the rpt file would be incorrect. 

This PR allows users to call massbal_getFlowError multiple times during a simulation by setting isFinalStorage=False.

### Changes to massbal_getRoutingTotal

* routing pctError is no longer multiplied by 100 since it is already stored as a percentage and not a fraction

### Changes to massbal_getRunoffError

* returned units are all now in terms of depth (in or mm) over the model catchment area (aligned with how they are presented in the rpt file)
* runoff pctError is no longer multiplied by 100 since it is already stored as a percentage and not a fraction
