### PR TITLE
Make get series function endPeriod inclusive

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -152,7 +152,7 @@ jobs:
 
       - name: Upload artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-test-artifacts
           path: upload/*.*

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, ubuntu-20.04, macos-12]
+        os: [windows-2022, ubuntu-22.04, macos-12]
         requirements: [requirements-swmm.txt]
         include:
           - os: windows-2022

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -40,9 +40,9 @@ jobs:
                 shell: cmd
                 working-directory: ./ci-tools/windows
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             sys_pkgs: sudo apt install libboost-dev libboost-all-dev
-            boost_platform_version: 20.04
+            boost_platform_version: 22.04
             boost_toolsit: gcc
             # Statically link libraries with -s switch to address GitHub Ubuntu 20.04 symbol errors (issue #340)
             build_unit_test: make.sh -s -t -g "Unix Makefiles"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, ubuntu-22.04, macos-12]
+        os: [windows-2022, ubuntu-22.04, macos-latest]
         requirements: [requirements-swmm.txt]
         include:
           - os: windows-2022
@@ -58,7 +58,7 @@ jobs:
                 shell: bash
                 working-directory: ./ci-tools/linux
 
-          - os: macos-12
+          - os: macos-latest
             sys_pkgs: brew install libomp #boost
             boost_platform_version: 12
             boost_toolsit: clang

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.7"
 
       - name: Install requirements
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.9"
 
       - name: Install requirements
         run: |

--- a/src/outfile/swmm_output.c
+++ b/src/outfile/swmm_output.c
@@ -120,7 +120,7 @@ int EXPORT_OUT_API SMO_init(SMO_Handle *p_handle)
     if (priv_data != NULL) {
         priv_data->error_handle = new_errormanager(&errorLookup);
         *p_handle = priv_data;
-    } 
+    }
     else
         errorcode = -1;
 
@@ -489,12 +489,12 @@ int EXPORT_OUT_API SMO_getSubcatchSeries(SMO_Handle p_handle, int subcatchIndex,
         errorcode = -1;
     else if (subcatchIndex < 0 || subcatchIndex > p_data->Nsubcatch)
         errorcode = 420;
-    else if (startPeriod < 0 || startPeriod >= p_data->Nperiods ||
-             endPeriod <= startPeriod)
+    else if (startPeriod < 0 || endPeriod < startPeriod ||
+        endPeriod >= p_data->Nperiods)
         errorcode = 422;
     // Check memory for outValues
     else if
-        MEMCHECK(temp = newFloatArray(len = endPeriod - startPeriod))
+        MEMCHECK(temp = newFloatArray(len = endPeriod - startPeriod + 1))
     errorcode = 411;
     else {
         // loop over and build time series
@@ -527,12 +527,12 @@ int EXPORT_OUT_API SMO_getNodeSeries(SMO_Handle p_handle, int nodeIndex,
         errorcode = -1;
     else if (nodeIndex < 0 || nodeIndex > p_data->Nnodes)
         errorcode = 420;
-    else if (startPeriod < 0 || startPeriod >= p_data->Nperiods ||
-             endPeriod <= startPeriod)
+        else if (startPeriod < 0 || endPeriod < startPeriod ||
+            endPeriod >= p_data->Nperiods)
         errorcode = 422;
     // Check memory for outValues
     else if
-        MEMCHECK(temp = newFloatArray(len = endPeriod - startPeriod))
+        MEMCHECK(temp = newFloatArray(len = endPeriod - startPeriod + 1))
     errorcode = 411;
     else {
         // loop over and build time series
@@ -564,12 +564,12 @@ int EXPORT_OUT_API SMO_getLinkSeries(SMO_Handle p_handle, int linkIndex,
         errorcode = -1;
     else if (linkIndex < 0 || linkIndex > p_data->Nlinks)
         errorcode = 420;
-    else if (startPeriod < 0 || startPeriod >= p_data->Nperiods ||
-             endPeriod <= startPeriod)
+        else if (startPeriod < 0 || endPeriod < startPeriod ||
+            endPeriod >= p_data->Nperiods)
         errorcode = 422;
     // Check memory for outValues
     else if
-        MEMCHECK(temp = newFloatArray(len = endPeriod - startPeriod))
+        MEMCHECK(temp = newFloatArray(len = endPeriod - startPeriod + 1))
     errorcode = 411;
     else {
         // loop over and build time series
@@ -598,12 +598,12 @@ int EXPORT_OUT_API SMO_getSystemSeries(SMO_Handle p_handle, SMO_systemAttribute 
 
     if (p_data == NULL)
         errorcode = -1;
-    else if (startPeriod < 0 || startPeriod >= p_data->Nperiods ||
-             endPeriod <= startPeriod)
+        else if (startPeriod < 0 || endPeriod < startPeriod ||
+            endPeriod >= p_data->Nperiods)
         errorcode = 422;
     // Check memory for outValues
     else if
-        MEMCHECK(temp = newFloatArray(len = endPeriod - startPeriod))
+        MEMCHECK(temp = newFloatArray(len = endPeriod - startPeriod + 1))
     errorcode = 411;
     else {
         // loop over and build time series

--- a/tests/outfile/test_output.cpp
+++ b/tests/outfile/test_output.cpp
@@ -254,13 +254,13 @@ BOOST_FIXTURE_TEST_CASE(test_getSubcatchSeries, Fixture) {
                                   &array_dim);
     BOOST_REQUIRE(error == 0);
 
-    const int ref_dim            = 10;
+    const int ref_dim            = 11;
     float     ref_array[ref_dim] = {
         0.0f, 1.2438242f, 2.5639679f, 4.524055f, 2.5115132f, 0.69808137f,
-		0.040894926f, 0.011605669f, 0.00509294f, 0.0027438672f};
+		0.040894926f, 0.011605669f, 0.00509294f, 0.0027438672f, 0.00167188f};
 
     std::vector<float> ref_vec;
-    ref_vec.assign(ref_array, ref_array + 10);
+    ref_vec.assign(ref_array, ref_array + ref_dim);
 
     std::vector<float> test_vec;
     test_vec.assign(array, array + array_dim);
@@ -273,13 +273,13 @@ BOOST_FIXTURE_TEST_CASE(test_getSystemSeries, Fixture) {
                                   &array_dim);
     BOOST_REQUIRE(error == 0);
 
-    const int ref_dim            = 10;
+    const int ref_dim            = 11;
     float     ref_array[ref_dim] = {
         0.0f, 6.216825f, 13.030855f, 24.252975f, 14.172027f, 4.1949716f,
-		0.322329f, 0.056010f, 0.024938f, 0.012474f};
+		0.322329f, 0.056010f, 0.024938f, 0.012474f, 0.00766089f};
 
     std::vector<float> ref_vec;
-    ref_vec.assign(ref_array, ref_array + 10);
+    ref_vec.assign(ref_array, ref_array + ref_dim);
 
     std::vector<float> test_vec;
     test_vec.assign(array, array + array_dim);


### PR DESCRIPTION
This pull request updates the time series retrieval logic in `src/outfile/swmm_output.c` and its corresponding tests to correctly handle inclusive end periods when fetching output data. The changes ensure that the requested time series includes both the start and end period, and that input validation matches this behavior. The related tests are updated to expect the correct array sizes and values.

**Time series retrieval logic improvements:**

* Updated input validation in `SMO_getSubcatchSeries`, `SMO_getNodeSeries`, `SMO_getLinkSeries`, and `SMO_getSystemSeries` to ensure `endPeriod` is within bounds, reflecting inclusive range semantics. 

**Test updates:**

* Increased the reference array size from 10 to 11 in `test_getSubcatchSeries` and `test_getSystemSeries` in `tests/outfile/test_output.cpp`, and added the expected value for the new endpoint. This verifies the inclusive behavior and corrects the expected results. 
