### PR TITLE
Refactor SMO_open to validate file only if opened successfully; add test

### DIFF
--- a/src/outfile/swmm_output.c
+++ b/src/outfile/swmm_output.c
@@ -241,9 +241,9 @@ int EXPORT_OUT_API SMO_open(SMO_Handle p_handle, const char *path)
                         p_data->Nlinks * p_data->LinkVars + p_data->SysVars) *
                         RECORDSIZE;
             }
+// ############################################################################
         }
     }
-// ############################################################################
 
     // If error close the binary file
     if (errorcode > 400) {

--- a/src/outfile/swmm_output.c
+++ b/src/outfile/swmm_output.c
@@ -120,7 +120,7 @@ int EXPORT_OUT_API SMO_init(SMO_Handle *p_handle)
     if (priv_data != NULL) {
         priv_data->error_handle = new_errormanager(&errorLookup);
         *p_handle = priv_data;
-    } 
+    }
     else
         errorcode = -1;
 
@@ -185,6 +185,7 @@ int EXPORT_OUT_API SMO_open(SMO_Handle p_handle, const char *path)
         if ((_fopen(&(p_data->file), path, "rb")) != 0)
             errorcode = 434;
 
+// PYSWMM EDIT ################################################################
         // Only validate if file was opened successfully
         if (errorcode == 0) {
             if ((err = validateFile(p_data)) != 0)
@@ -242,7 +243,8 @@ int EXPORT_OUT_API SMO_open(SMO_Handle p_handle, const char *path)
             }
         }
     }
-        
+// ############################################################################
+
     // If error close the binary file
     if (errorcode > 400) {
         set_error(p_data->error_handle, errorcode);

--- a/tests/outfile/test_output.cpp
+++ b/tests/outfile/test_output.cpp
@@ -103,6 +103,19 @@ BOOST_AUTO_TEST_CASE(InitOpenCloseTest) {
     SMO_close(p_handle);
 }
 
+BOOST_AUTO_TEST_CASE(OpenNonexistentFileTest) {
+    SMO_Handle p_handle = NULL;
+    int error = SMO_init(&p_handle);
+    BOOST_REQUIRE(error == 0);
+
+    // Try to open a file that does not exist
+    std::string bad_path = "./this_file_does_not_exist.out";
+    error = SMO_open(p_handle, bad_path.c_str());
+
+    // Should return error code 434 (file open error)
+    BOOST_CHECK_EQUAL(error, 434);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 struct Fixture {


### PR DESCRIPTION
This pull request improves error handling when opening output files and adds a new test to ensure proper behavior when attempting to open a non-existent file. The main changes include modifying the file validation logic in `SMO_open` and introducing a test case for file open errors.

Error handling improvements:

* Updated `SMO_open` in `src/outfile/swmm_output.c` to only validate the output file if it was opened successfully, preventing unnecessary validation attempts and ensuring correct error codes are set.
* Ensured that error handling and file closing logic in `SMO_open` runs only after all file operations, improving reliability.

Testing enhancements:

* Added `OpenNonexistentFileTest` in `tests/outfile/test_output.cpp` to verify that attempting to open a non-existent file returns error code 434, confirming correct error handling for missing files.

Close #413 