### PR TITLE
Temp file management on linux+mac

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Before reg test
         env:
           NRTESTS_URL: https://github.com/pyswmm/swmm-nrtestsuite
-          BENCHMARK_TAG: v3.1.0
+          BENCHMARK_TAG: v3.2.0
         run: ./${{ matrix.before_reg_test }} ${{ env.BENCHMARK_TAG }}
 
       - name: Run reg test

--- a/src/solver/swmm5.c
+++ b/src/solver/swmm5.c
@@ -1545,8 +1545,22 @@ char* getTempFileName(char* fname)
 // For non-Windows systems:
 #else
 
+   // PYSWMM EDIT: put scratchfile in tempdir #############################
+    const char *tmpdir;
+    if (strlen(TempDir) > 0) {
+        tmpdir = TempDir;
+    } else if (getenv("TMPDIR") && strlen(getenv("TMPDIR")) > 0) {
+        tmpdir = getenv("TMPDIR");
+    } else {
+        #ifdef P_tmpdir
+            tmpdir = P_tmpdir; // fallback to system default in stdio.h
+        #else
+            tmpdir = "/tmp"; // fallback to hardcoded default
+        #endif
+    }
     // --- use system function mkstemp() to create a temporary file name
-    sstrncpy(fname, "swmmXXXXXX", MAXFNAME);
+    snprintf(fname, MAXFNAME, "%s/swmmXXXXXX", tmpdir);
+    // #####################################################################
     mkstemp(fname);
     return fname;
 


### PR DESCRIPTION
This PR address #416 and bumps regression test benchmark files for mac and windows, which was necessary since the large shift in build tools in the latest github action runner images.