### PR TITLE
Dev unittests actions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -37,7 +37,7 @@ jobs:
                 shell: cmd
                 working-directory: ./ci-tools/windows
 
-          - os: ubuntu-24.04
+          - os: ubuntu-latest
             # Statically link libraries with -s switch to address GitHub Ubuntu 20.04 symbol errors (issue #340)
             build_unit_test: make.sh -s -t -g "Unix Makefiles"
             build_reg_test: make.sh -s -g "Unix Makefiles"
@@ -52,7 +52,7 @@ jobs:
                 shell: bash
                 working-directory: ./ci-tools/linux
 
-          - os: macos-15
+          - os: macos-latest
             build_unit_test: make.zsh -t -g "Xcode"
             build_reg_test: make.zsh -g "Xcode"
             before_reg_test: before-nrtest.zsh

--- a/tests/solver/test_lid.cpp
+++ b/tests/solver/test_lid.cpp
@@ -24,6 +24,7 @@
 #define ERR_TKAPI_SIM_NRUNNING 2002
 #define ERR_TKAPI_OBJECT_INDEX 2004
 #define ERR_TKAPI_UNDEFINED_LID 2010
+#define ERR_TKAPI_SIM_RUNNING 2013
 
 using namespace std;
 
@@ -159,43 +160,43 @@ BOOST_AUTO_TEST_SUITE(test_lid_toolkitapi_fixture)
 
         //Lid Surface
         error = swmm_setLidCParam(0, SM_SURFACE, SM_THICKNESS, db_value);
-        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_NRUNNING);
+        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_RUNNING);
         error = swmm_setLidCParam(0, SM_SURFACE, SM_VOIDFRAC, db_value);
-        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_NRUNNING);
+        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_RUNNING);
         error = swmm_setLidCParam(0, SM_SURFACE, SM_ROUGHNESS, db_value);
         BOOST_CHECK_EQUAL(error, ERR_NONE);
         error = swmm_setLidCParam(0, SM_SURFACE, SM_SURFSLOPE, db_value);
-        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_NRUNNING);
+        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_RUNNING);
         error = swmm_setLidCParam(0, SM_SURFACE, SM_SIDESLOPE, db_value);
-        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_NRUNNING);
+        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_RUNNING);
         error = swmm_setLidCParam(0, SM_SURFACE, SM_ALPHA, db_value);
         BOOST_CHECK_EQUAL(error, ERR_TKAPI_OUTBOUNDS);
 
         //Lid Soil
         error = swmm_setLidCParam(0, SM_SOIL, SM_THICKNESS, db_value);
-        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_NRUNNING);
+        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_RUNNING);
         error = swmm_setLidCParam(0, SM_SOIL, SM_POROSITY, db_value);
-        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_NRUNNING);
+        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_RUNNING);
         error = swmm_setLidCParam(0, SM_SOIL, SM_FIELDCAP, db_value);
-        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_NRUNNING);
+        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_RUNNING);
         error = swmm_setLidCParam(0, SM_SOIL, SM_WILTPOINT, db_value);
-        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_NRUNNING);
+        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_RUNNING);
         error = swmm_setLidCParam(0, SM_SOIL, SM_SUCTION, db_value);
-        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_NRUNNING);
+        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_RUNNING);
         error = swmm_setLidCParam(0, SM_SOIL, SM_KSAT, db_value);
-        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_NRUNNING);
+        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_RUNNING);
         error = swmm_setLidCParam(0, SM_SOIL, SM_KSLOPE, db_value);
-        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_NRUNNING);
+        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_RUNNING);
         error = swmm_setLidCParam(0, SM_SOIL, SM_CLOGFACTOR, db_value);
         BOOST_CHECK_EQUAL(error, ERR_TKAPI_OUTBOUNDS);
 
         //Lid Storage
         error = swmm_setLidCParam(0, SM_STOR, SM_THICKNESS, db_value);
-        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_NRUNNING);
+        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_RUNNING);
         error = swmm_setLidCParam(0, SM_STOR, SM_VOIDFRAC, db_value);
-        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_NRUNNING);
+        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_RUNNING);
         error = swmm_setLidCParam(0, SM_STOR, SM_KSAT, db_value);
-        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_NRUNNING);
+        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_RUNNING);
         error = swmm_setLidCParam(0, SM_STOR, SM_CLOGFACTOR, db_value);
         BOOST_CHECK_EQUAL(error, ERR_NONE);
         error = swmm_setLidCParam(0, SM_STOR, SM_ROUGHNESS, db_value);
@@ -203,19 +204,19 @@ BOOST_AUTO_TEST_SUITE(test_lid_toolkitapi_fixture)
 
         //Lid Pavement
         error = swmm_setLidCParam(0, SM_PAVE, SM_THICKNESS, db_value);
-        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_NRUNNING);
+        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_RUNNING);
         error = swmm_setLidCParam(0, SM_PAVE, SM_VOIDFRAC, db_value);
-        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_NRUNNING);
+        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_RUNNING);
         error = swmm_setLidCParam(0, SM_PAVE, SM_IMPERVFRAC, db_value);
-        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_NRUNNING);
+        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_RUNNING);
         error = swmm_setLidCParam(0, SM_PAVE, SM_KSAT, db_value);
-        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_NRUNNING);
+        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_RUNNING);
         error = swmm_setLidCParam(0, SM_PAVE, SM_CLOGFACTOR, db_value);
         BOOST_CHECK_EQUAL(error, ERR_NONE);
         error = swmm_setLidCParam(0, SM_PAVE, SM_REGENDAYS, db_value);
-        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_NRUNNING);
+        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_RUNNING);
         error = swmm_setLidCParam(0, SM_PAVE, SM_REGENDEGREE, db_value);
-        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_NRUNNING);
+        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_RUNNING);
         error = swmm_setLidCParam(0, SM_PAVE, SM_WILTPOINT, db_value);
         BOOST_CHECK_EQUAL(error, ERR_TKAPI_OUTBOUNDS);
 
@@ -237,9 +238,9 @@ BOOST_AUTO_TEST_SUITE(test_lid_toolkitapi_fixture)
 
         //Lid DrainMat
         error = swmm_setLidCParam(0, SM_DRAINMAT, SM_THICKNESS, db_value);
-        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_NRUNNING);
+        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_RUNNING);
         error = swmm_setLidCParam(0, SM_DRAINMAT, SM_VOIDFRAC, db_value);
-        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_NRUNNING);
+        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_RUNNING);
         error = swmm_setLidCParam(0, SM_DRAINMAT, SM_ROUGHNESS, db_value);
         BOOST_CHECK_EQUAL(error, ERR_NONE);
         error = swmm_setLidCParam(0, SM_DRAINMAT, SM_CLOGFACTOR, db_value);
@@ -251,15 +252,15 @@ BOOST_AUTO_TEST_SUITE(test_lid_toolkitapi_fixture)
         error = swmm_getLidUParam(0, 0, SM_UNITAREA, &db_value);
         BOOST_CHECK_EQUAL(error, ERR_NONE);
         error = swmm_setLidUParam(0, 0, SM_UNITAREA, db_value);
-        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_NRUNNING);
+        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_RUNNING);
         error = swmm_getLidUOption(0, 0, SM_INDEX, &int_value);
         BOOST_CHECK_EQUAL(error, ERR_NONE);
         error = swmm_setLidUOption(0, 0, SM_INDEX, int_value);
-        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_NRUNNING);
+        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_RUNNING);
         error = swmm_setLidUOption(0, 0, SM_NUMBER, int_value);
-        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_NRUNNING);
+        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_RUNNING);
         error = swmm_setLidUOption(0, 0, SM_TOPERV, int_value);
-        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_NRUNNING);
+        BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_RUNNING);
         error = swmm_setLidUOption(0, 0, SM_DRAINSUB, int_value);
         BOOST_CHECK_EQUAL(error, ERR_NONE);
         error = swmm_setLidUOption(0, 0, SM_DRAINNODE, int_value);

--- a/tests/solver/test_toolkit.cpp
+++ b/tests/solver/test_toolkit.cpp
@@ -132,20 +132,20 @@ BOOST_FIXTURE_TEST_CASE(sim_started_check, FixtureBeforeStep) {
     BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_RUNNING);
     //Subcatchment
     error = swmm_setSubcatchParam(0, SM_WIDTH, 1);
-    BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_NRUNNING);
+    BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_RUNNING);
 
 
     //Node
     error = swmm_setNodeParam(0, SM_INVERTEL, 1);
-    BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_NRUNNING);
+    BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_RUNNING);
 
 
     //Link
     error = swmm_setLinkParam(0, SM_OFFSET1, 1);
-    BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_NRUNNING);
+    BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_RUNNING);
 
     error = swmm_setLinkParam(0, SM_OFFSET2, 1);
-    BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_NRUNNING);
+    BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_RUNNING);
 
     error = swmm_setLinkParam(0, SM_INITFLOW, 1);
     BOOST_CHECK_EQUAL(error, ERR_NONE);


### PR DESCRIPTION
This pull request updates error code usage in the test suite to ensure consistency and correctness, and modernizes the CI build matrix to use the latest available runner images. The main changes are grouped below:

**Test Suite Error Code Consistency:**

* Replaced all instances of `ERR_TKAPI_SIM_NRUNNING` with the correct error code `ERR_TKAPI_SIM_RUNNING` in `tests/solver/test_lid.cpp` and `tests/solver/test_toolkit.cpp` to reflect the intended simulation state error in various parameter-setting tests. [[1]](diffhunk://#diff-4470cfd2b2946645d5550f87cccd8b69803e433d8e86bd34a2acc8041c8d0171L162-R219) [[2]](diffhunk://#diff-4470cfd2b2946645d5550f87cccd8b69803e433d8e86bd34a2acc8041c8d0171L240-R243) [[3]](diffhunk://#diff-4470cfd2b2946645d5550f87cccd8b69803e433d8e86bd34a2acc8041c8d0171L254-R263) [[4]](diffhunk://#diff-a7cbd7e88adb39170849e2a3ce4d6bc25a05c271ce64ee8cb6785ccbed71b665L135-R148)
* Added a new error code definition `ERR_TKAPI_SIM_RUNNING` (value 2013) in `tests/solver/test_lid.cpp` for clarity and consistency.

**CI Build Matrix Modernization:**

* Updated the GitHub Actions workflow in `.github/workflows/build-test.yml` to use `ubuntu-latest` instead of `ubuntu-24.04` and `macos-latest` instead of `macos-15`, ensuring the CI uses the most current runner environments. [[1]](diffhunk://#diff-063ca77e012f959eba648db60e6868875fd1e70e5f5ac081193d848f8d61ef32L40-R40) [[2]](diffhunk://#diff-063ca77e012f959eba648db60e6868875fd1e70e5f5ac081193d848f8d61ef32L55-R55)